### PR TITLE
Allow turkish players to use this mod

### DIFF
--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/steam_vent/SteamVentBlock.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/steam_vent/SteamVentBlock.java
@@ -158,7 +158,7 @@ public class SteamVentBlock extends Block implements IBE<SteamVentBlockEntity>, 
 
         @Override
         public String getSerializedName() {
-            return this.toString().toLowerCase();
+            return this.toString().toLowerCase(Locale.ROOT);
         }
     }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/altitude_sensor/AltitudeSensorBlock.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/altitude_sensor/AltitudeSensorBlock.java
@@ -34,6 +34,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 import static net.minecraft.world.level.block.state.properties.BlockStateProperties.HORIZONTAL_FACING;
 
 public class AltitudeSensorBlock extends FaceAttachedHorizontalDirectionalBlock implements IBE<AltitudeSensorBlockEntity>, IWrenchable, CommonRedstoneBlock {
@@ -177,7 +179,7 @@ public class AltitudeSensorBlock extends FaceAttachedHorizontalDirectionalBlock 
 
         @Override
         public @NotNull String getSerializedName() {
-            return this.toString().toLowerCase();
+            return this.toString().toLowerCase(Locale.ROOT);
         }
     }
 

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/auger_shaft/AugerShaftBlock.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/auger_shaft/AugerShaftBlock.java
@@ -51,6 +51,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -264,7 +265,7 @@ public class AugerShaftBlock extends RotatedPillarKineticBlock implements IBE<Au
 
         @Override
         public String getSerializedName() {
-            return this.toString().toLowerCase();
+            return this.toString().toLowerCase(Locale.ROOT);
         }
     }
 


### PR DESCRIPTION
string#toLowerCase() is system (or jvm) language dependent causing the I to turn into an ı, which is not an allowed character in ResourceLocations/Registries.
Fixes: #45 