### PR TITLE
Fix multiple bugs and null pointer exceptions

### DIFF
--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/BlockEntityLiftingGasProvider.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/BlockEntityLiftingGasProvider.java
@@ -101,12 +101,18 @@ public interface BlockEntityLiftingGasProvider {
         final BlockPos castPos = this.getCastPosition();
 
         if (castPos != null) {
-            final Balloon existingBalloon = BalloonMap.MAP.get(this.getLevel()).getBalloon(castPos);
+            final Level level = this.getLevel();
+            if (level != null) {
+                final BalloonMap balloonMap = BalloonMap.MAP.get(level);
+                if (balloonMap != null) {
+                    final Balloon existingBalloon = balloonMap.getBalloon(castPos);
 
-            if (existingBalloon != null) {
-                // Yip yip!
-                existingBalloon.addHeater(this);
-                this.setBalloon(existingBalloon);
+                    if (existingBalloon != null) {
+                        // Yip yip!
+                        existingBalloon.addHeater(this);
+                        this.setBalloon(existingBalloon);
+                    }
+                }
             }
         }
     }
@@ -171,7 +177,10 @@ public interface BlockEntityLiftingGasProvider {
                 final Level level = this.getLevel();
                 assert level != null;
 
-                BalloonMap.MAP.get(level).unloadBalloon(serverBalloon);
+                final BalloonMap balloonMap = BalloonMap.MAP.get(level);
+                if (balloonMap != null) {
+                    balloonMap.unloadBalloon(serverBalloon);
+                }
             }
 
             this.setBalloon(null);

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/effect/ClientBalloonEffectRenderer.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/effect/ClientBalloonEffectRenderer.java
@@ -53,7 +53,7 @@ public class ClientBalloonEffectRenderer {
         }
 
         final BalloonMap ballonMap = BalloonMap.MAP.get(level);
-        if (ballonMap.isEmpty()) {
+        if (ballonMap == null || ballonMap.isEmpty()) {
             freeFbo();
             return;
         }

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/map/BalloonLevelSavedData.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/map/BalloonLevelSavedData.java
@@ -30,7 +30,9 @@ public class BalloonLevelSavedData extends SavedData {
             final DataResult<Pair<List<SavedBalloon>, Tag>> result = CODEC.decode(NbtOps.INSTANCE, tag.getList(ID, Tag.TAG_COMPOUND));
 
             final BalloonMap map = BalloonMap.MAP.get(level);
-            result.ifSuccess(x -> map.getUnloadedBalloons().addAll(x.getFirst()));
+            if (map != null) {
+                result.ifSuccess(x -> map.getUnloadedBalloons().addAll(x.getFirst()));
+            }
         }
         return sd;
     }
@@ -47,14 +49,16 @@ public class BalloonLevelSavedData extends SavedData {
     @Override
     public @NotNull CompoundTag save(final CompoundTag tag, final HolderLookup.@NotNull Provider provider) {
         final BalloonMap map = BalloonMap.MAP.get(this.level);
-        final ObjectArrayList<SavedBalloon> list = new ObjectArrayList<>(map.getUnloadedBalloons());
+        if (map != null) {
+            final ObjectArrayList<SavedBalloon> list = new ObjectArrayList<>(map.getUnloadedBalloons());
 
-        for (final Balloon balloon : map.getBalloons()) {
-            list.add(BalloonMap.saveBalloon((ServerBalloon) balloon));
+            for (final Balloon balloon : map.getBalloons()) {
+                list.add(BalloonMap.saveBalloon((ServerBalloon) balloon));
+            }
+
+            final DataResult<Tag> result = CODEC.encodeStart(NbtOps.INSTANCE, list);
+            result.ifSuccess(data -> tag.put(ID, data));
         }
-
-        final DataResult<Tag> result = CODEC.encodeStart(NbtOps.INSTANCE, list);
-        result.ifSuccess(data -> tag.put(ID, data));
 
         return tag;
     }

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/map/BalloonMap.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/map/BalloonMap.java
@@ -36,7 +36,10 @@ public class BalloonMap {
     }
 
     public static void tick(final Level level) {
-        MAP.get(level).tick();
+        final BalloonMap balloonMap = MAP.get(level);
+        if (balloonMap != null) {
+            balloonMap.tick();
+        }
     }
 
     public static void physicsTick(final ServerLevel level, final double timeStep) {
@@ -234,18 +237,20 @@ public class BalloonMap {
                 final LevelPlot plot = subLevel.getPlot();
 
                 final BalloonMap map = BalloonMap.MAP.get(this.level);
-                final Iterator<Balloon> iter = map.getBalloons().iterator();
+                if (map != null) {
+                    final Iterator<Balloon> iter = map.getBalloons().iterator();
 
-                while (iter.hasNext()) {
-                    final Balloon balloon = iter.next();
+                    while (iter.hasNext()) {
+                        final Balloon balloon = iter.next();
 
-                    if (balloon.isAssembling())
-                        continue;
+                        if (balloon.isAssembling())
+                            continue;
 
-                    final BlockPos controllerPos = balloon.getControllerPos();
-                    if (plot.contains(controllerPos.getX(), controllerPos.getZ())) {
-                        balloon.onRemoved();
-                        iter.remove();
+                        final BlockPos controllerPos = balloon.getControllerPos();
+                        if (plot.contains(controllerPos.getX(), controllerPos.getZ())) {
+                            balloon.onRemoved();
+                            iter.remove();
+                        }
                     }
                 }
             }

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/propeller/bearing/propeller_bearing/PropellerBearingBlockEntity.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/propeller/bearing/propeller_bearing/PropellerBearingBlockEntity.java
@@ -88,8 +88,6 @@ public class PropellerBearingBlockEntity extends MechanicalBearingBlockEntity im
 
         this.sailPositions = new ArrayList<>();
         this.thrustDirection = new Vector3d();
-
-        this.behavior.setThrustDirection(this.thrustDirection);
     }
 
     private static double getConfigAirflowMult() {
@@ -397,6 +395,7 @@ public class PropellerBearingBlockEntity extends MechanicalBearingBlockEntity im
     public void contraptionInitialize() {
         final Direction direction = this.getBlockState().getValue(PropellerBearingBlock.FACING);
         this.thrustDirection.set(direction.getStepX(), direction.getStepY(), direction.getStepZ());
+        this.behavior.setThrustDirection(this.thrustDirection);
         this.findSails();
     }
 

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/events/AeronauticsCommonEvents.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/events/AeronauticsCommonEvents.java
@@ -27,7 +27,10 @@ public class AeronauticsCommonEvents {
      * Called whenever a block is modified in the given level
      */
     public static void onBlockModifiedEvent(final LevelAccessor level, final BlockPos blockPos, final BlockState oldState, final BlockState newState) {
-        BalloonMap.MAP.get(level).updateNearbyBalloons(blockPos, oldState, newState);
+        final BalloonMap balloonMap = BalloonMap.MAP.get(level);
+        if (balloonMap != null) {
+            balloonMap.updateNearbyBalloons(blockPos, oldState, newState);
+        }
     }
 
     /**

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/mixin/balloon/LevelChunkMixin.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/mixin/balloon/LevelChunkMixin.java
@@ -35,7 +35,10 @@ public class LevelChunkMixin {
         final BlockState oldState = original.call(instance, pX, pY, pZ, newState);
 
         if (this.level.isClientSide() && oldState != newState) {
-            BalloonMap.MAP.get(this.level).updateNearbyBalloons(this.simulated$blockSet, oldState, newState);
+            final BalloonMap balloonMap = BalloonMap.MAP.get(this.level);
+            if (balloonMap != null) {
+                balloonMap.updateNearbyBalloons(this.simulated$blockSet, oldState, newState);
+            }
         }
 
         return oldState;

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/mixin/balloon/SimAssemblyHelperMixin.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/mixin/balloon/SimAssemblyHelperMixin.java
@@ -30,12 +30,13 @@ public class SimAssemblyHelperMixin {
                                                 final CallbackInfo ci,
                                                 @Local final SubLevelAssemblyHelper.AssemblyTransform transform) {
         final BalloonMap balloonMap = BalloonMap.MAP.get(level);
-
-        for (final Balloon balloon : balloonMap.getBalloons()) {
-            final BlockPos controllerPos = balloon.getControllerPos();
-            if (toDisassemble.getPlot().contains(controllerPos.getX(), controllerPos.getZ())) {
-                balloon.setAssembling(transform);
-                return;
+        if (balloonMap != null) {
+            for (final Balloon balloon : balloonMap.getBalloons()) {
+                final BlockPos controllerPos = balloon.getControllerPos();
+                if (toDisassemble.getPlot().contains(controllerPos.getX(), controllerPos.getZ())) {
+                    balloon.setAssembling(transform);
+                    return;
+                }
             }
         }
     }

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/mixin/balloon/SubLevelAssemblyHelperMixin.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/mixin/balloon/SubLevelAssemblyHelperMixin.java
@@ -28,11 +28,12 @@ public class SubLevelAssemblyHelperMixin {
     @Inject(method = "needsBitSet", at = @At("HEAD"), cancellable = true)
     private static void aeronautics$needsBitSet(final ServerLevel level, final BoundingBox3ic bounds, final List<Entity> entities, final CallbackInfoReturnable<Boolean> cir) {
         final BalloonMap balloonMap = BalloonMap.MAP.get(level);
-
-        for (final Balloon balloon : balloonMap.getBalloons()) {
-            if (balloon.getBounds().intersects(bounds)) {
-                cir.setReturnValue(true);
-                return;
+        if (balloonMap != null) {
+            for (final Balloon balloon : balloonMap.getBalloons()) {
+                if (balloon.getBounds().intersects(bounds)) {
+                    cir.setReturnValue(true);
+                    return;
+                }
             }
         }
     }
@@ -45,28 +46,29 @@ public class SubLevelAssemblyHelperMixin {
                                              final CallbackInfo ci,
                                              @Local final BoundedBitVolume3i volume) {
         final BalloonMap balloonMap = BalloonMap.MAP.get(level);
-
-        for (final Balloon balloon : balloonMap.getBalloons()) {
-            if (!balloon.getBounds().intersects(bounds)) {
-                continue;
-            }
-
-            boolean shouldMoveBalloon = false;
-
-            for (final Direction direction : SimDirectionUtil.VALUES) {
-                final BlockPos relativePos = balloon.getControllerPos().relative(direction);
-
-                if (volume.getOccupied(relativePos.getX(), relativePos.getY(), relativePos.getZ())) {
-                    shouldMoveBalloon = true;
-                    break;
+        if (balloonMap != null) {
+            for (final Balloon balloon : balloonMap.getBalloons()) {
+                if (!balloon.getBounds().intersects(bounds)) {
+                    continue;
                 }
-            }
 
-            if (!shouldMoveBalloon) {
-                continue;
-            }
+                boolean shouldMoveBalloon = false;
 
-            balloon.setAssembling(transform);
+                for (final Direction direction : SimDirectionUtil.VALUES) {
+                    final BlockPos relativePos = balloon.getControllerPos().relative(direction);
+
+                    if (volume.getOccupied(relativePos.getX(), relativePos.getY(), relativePos.getZ())) {
+                        shouldMoveBalloon = true;
+                        break;
+                    }
+                }
+
+                if (!shouldMoveBalloon) {
+                    continue;
+                }
+
+                balloon.setAssembling(transform);
+            }
         }
     }
 

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/util/AeroSoundDistUtil.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/util/AeroSoundDistUtil.java
@@ -43,14 +43,20 @@ public class AeroSoundDistUtil {
         final ClientLevel level = minecraft.level;
         final SoundManager soundManager = minecraft.getSoundManager();
 
-        if (level != null) {
-            if (!soundManager.isActive(BalloonBurnerSoundInstance.GLOBAL_HOT_AIR_BURNER_SOUND)) {
-                soundManager.queueTickingSound(BalloonBurnerSoundInstance.GLOBAL_HOT_AIR_BURNER_SOUND);
-            }
+        if (level == null) {
+            return;
+        }
 
-            if (!soundManager.isActive(BalloonBurnerSoundInstance.GLOBAL_STEAM_VENT_AIR_BURNER_SOUND)) {
-                soundManager.queueTickingSound(BalloonBurnerSoundInstance.GLOBAL_STEAM_VENT_AIR_BURNER_SOUND);
-            }
+        if (minecraft.isPaused()) {
+            return;
+        }
+
+        if (!soundManager.isActive(BalloonBurnerSoundInstance.GLOBAL_HOT_AIR_BURNER_SOUND)) {
+            soundManager.queueTickingSound(BalloonBurnerSoundInstance.GLOBAL_HOT_AIR_BURNER_SOUND);
+        }
+
+        if (!soundManager.isActive(BalloonBurnerSoundInstance.GLOBAL_STEAM_VENT_AIR_BURNER_SOUND)) {
+            soundManager.queueTickingSound(BalloonBurnerSoundInstance.GLOBAL_STEAM_VENT_AIR_BURNER_SOUND);
         }
     }
 


### PR DESCRIPTION
This PR addresses several critical issues in the Aeronautics module:

#### Fixed Issues:
1. **Propeller freeze when attaching propeller to engine** (Issue #198)
   - Root cause: Null pointer exception in `PropellerBearingBlockEntity` constructor when calling `behavior.setThrustDirection()` before `behavior` was initialized
   - Fix: Moved the `setThrustDirection` call from constructor to `contraptionInitialize()` method where behavior is properly initialized

2. **Sound spam/duplication when pausing game** (Issue #171)
   - Root cause: `tickGlobalBurnerSound()` was not checking if the game was paused, causing sounds to accumulate
   - Fix: Added `minecraft.isPaused()` check to prevent sound queuing during pause

3. **Multiple potential null pointer exceptions** in balloon-related code:
   - Added null checks for `BalloonMap.MAP.get()` calls in multiple files:
     - `AeronauticsCommonEvents.java`
     - `BalloonMap.java`
     - `LevelChunkMixin.java`
     - `BlockEntityLiftingGasProvider.java`
     - `SimAssemblyHelperMixin.java`
     - `SubLevelAssemblyHelperMixin.java`
     - `BalloonLevelSavedData.java`
     - `ClientBalloonEffectRenderer.java`

#### Changes Made:
- Modified `PropellerBearingBlockEntity.java` to fix constructor null pointer exception
- Updated `AeroSoundDistUtil.java` to add pause check
- Added null checks in multiple balloon-related files to prevent potential crashes

#### Testing:
- Tested propeller attachment without freezing
- Verified no sound duplication when pausing game
- Tested balloon functionality with various scenarios

### Related Issues:
- #198 - Propeller freeze when attaching to engine
- #171 - Sound spam when pausing game

### Note:
Some issues listed in the GitHub issues (such as #197, #196, #195, etc.) are related to the Sable physics engine and require fixes in the Sable repository. This PR only addresses issues within the Aeronautics module.