### PR TITLE
Fix velocity_sensor ComputerCraft peripheral multiplying by max_speed config

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/VelocitySensorPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/VelocitySensorPeripheral.java
@@ -16,6 +16,6 @@ public class VelocitySensorPeripheral extends SimPeripheral<VelocitySensorBlockE
 
     @LuaFunction
     public float getVelocity() {
-        return this.blockEntity.getAdjustedVelocity() * this.blockEntity.getMaxSpeed().getValue();
+        return this.blockEntity.getAdjustedVelocity();
     }
 }


### PR DESCRIPTION
getVelocity() was returning adjustedVelocity × maxSpeed, which is m/s × m/s. The redstone path already uses max_speed for normalization; the peripheral shouldn't apply it.