### PR TITLE
Add Rad-suffixed variants to angle ComputerCraft peripherals

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/DirectionalLinkPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/DirectionalLinkPeripheral.java
@@ -17,4 +17,9 @@ public class DirectionalLinkPeripheral extends SimPeripheral<DirectionalLinkedRe
     public double getClosestAngle() {
         return Math.toDegrees(this.blockEntity.getAngleToClosestLink());
     }
+
+    @LuaFunction
+    public double getClosestAngleRad() {
+        return this.blockEntity.getAngleToClosestLink();
+    }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/GimbalSensorPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/GimbalSensorPeripheral.java
@@ -20,4 +20,9 @@ public class GimbalSensorPeripheral extends SimPeripheral<GimbalSensorBlockEntit
     public List<Double> getAngles() {
         return List.of(Math.toDegrees(this.blockEntity.getXAngle()), Math.toDegrees(this.blockEntity.getZAngle()));
     }
+
+    @LuaFunction
+    public List<Double> getAnglesRad() {
+        return List.of(this.blockEntity.getXAngle(), this.blockEntity.getZAngle());
+    }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/NavTablePeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/NavTablePeripheral.java
@@ -18,4 +18,9 @@ public class NavTablePeripheral extends SimPeripheral<NavTableBlockEntity> {
     public Float getRelativeAngle() {
         return this.blockEntity.getRelativeAngle();
     }
+
+    @LuaFunction
+    public double getRelativeAngleRad() {
+        return Math.toRadians(this.blockEntity.getRelativeAngle());
+    }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/SwivelBearingPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/SwivelBearingPeripheral.java
@@ -18,4 +18,9 @@ public class SwivelBearingPeripheral extends SimPeripheral<SwivelBearingBlockEnt
     public double getTargetAngle() {
         return this.blockEntity.getTargetAngleDegrees();
     }
+
+    @LuaFunction
+    public double getTargetAngleRad() {
+        return Math.toRadians(this.blockEntity.getTargetAngleDegrees());
+    }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/TorsionSpringPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/TorsionSpringPeripheral.java
@@ -26,6 +26,11 @@ public class TorsionSpringPeripheral extends SimPeripheral<TorsionSpringBlockEnt
     }
 
     @LuaFunction
+    public double getAngleRad() {
+        return Math.toRadians(this.blockEntity.getAngle());
+    }
+
+    @LuaFunction
     public int getLimit() {
         return this.blockEntity.angleInput.getValue();
     }


### PR DESCRIPTION
Pure-additive rad siblings for every deg-returning angle peripheral (`getAnglesRad`, `getRelativeAngleRad`, `getClosestAngleRad`, `getTargetAngleRad`, `getAngleRad`). Autopilot/PID code works in radians; this removes the per-call conversion and the silent unit-mismatch bug when one is forgotten. Existing methods unchanged.