### PR TITLE
Add angular rates to gimbal_sensor ComputerCraft peripheral

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/GimbalSensorPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/GimbalSensorPeripheral.java
@@ -2,6 +2,7 @@ package dev.simulated_team.simulated.compat.computercraft.peripherals;
 
 import dan200.computercraft.api.lua.LuaFunction;
 import dev.simulated_team.simulated.content.blocks.gimbal_sensor.GimbalSensorBlockEntity;
+import org.joml.Vector3dc;
 
 import java.util.List;
 
@@ -19,5 +20,17 @@ public class GimbalSensorPeripheral extends SimPeripheral<GimbalSensorBlockEntit
     @LuaFunction
     public List<Double> getAngles() {
         return List.of(Math.toDegrees(this.blockEntity.getXAngle()), Math.toDegrees(this.blockEntity.getZAngle()));
+    }
+
+    @LuaFunction
+    public List<Double> getAngularRates() {
+        final Vector3dc w = this.blockEntity.getAngularVelocityBody();
+        return List.of(Math.toDegrees(w.x()), Math.toDegrees(w.y()), Math.toDegrees(w.z()));
+    }
+
+    @LuaFunction
+    public List<Double> getAngularRatesRad() {
+        final Vector3dc w = this.blockEntity.getAngularVelocityBody();
+        return List.of(w.x(), w.y(), w.z());
     }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/gimbal_sensor/GimbalSensorBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/gimbal_sensor/GimbalSensorBlockEntity.java
@@ -13,9 +13,11 @@ import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollVa
 import dev.engine_room.flywheel.lib.transform.TransformStack;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.api.SubLevelHelper;
+import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
 import dev.ryanhcode.sable.companion.math.Pose3d;
 import dev.ryanhcode.sable.companion.math.Pose3dc;
 import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData;
+import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import dev.ryanhcode.sable.sublevel.SubLevel;
 import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import dev.simulated_team.simulated.data.SimLang;
@@ -77,6 +79,8 @@ public class GimbalSensorBlockEntity extends SmartBlockEntity implements IHaveGo
     private double ZAngle;
     private double XAngle;
 
+    private final Vector3d angularVelocityBody = new Vector3d();
+
     public GimbalSensorBlockEntity(final BlockEntityType<?> type, final BlockPos pos, final BlockState state) {
         super(type, pos, state);
 
@@ -123,6 +127,11 @@ public class GimbalSensorBlockEntity extends SmartBlockEntity implements IHaveGo
 
         this.setPower(this.XAngle, Direction.SOUTH);
         this.setPower(-this.XAngle, Direction.NORTH);
+
+        if (subLevel instanceof final ServerSubLevel serverSubLevel) {
+            RigidBodyHandle.of(serverSubLevel).getAngularVelocity(this.angularVelocityBody);
+            serverSubLevel.logicalPose().orientation().transformInverse(this.angularVelocityBody);
+        }
     }
 
     public void randomNudge() {
@@ -297,6 +306,10 @@ public class GimbalSensorBlockEntity extends SmartBlockEntity implements IHaveGo
 
     public double getXAngle() {
         return this.XAngle;
+    }
+
+    public Vector3dc getAngularVelocityBody() {
+        return this.angularVelocityBody;
     }
 
     @Override


### PR DESCRIPTION
Exposes body-frame angular velocity as `getAngularRates` (deg/s) and `getAngularRatesRad` (rad/s, per the deg/rad convention from #273), three components `[ωx, ωy, ωz]`. Derived from Sable's `latestAngularVelocity` transformed into sub-level body frame each server tick. Enables rate-damped attitude control; differentiating `getAngles` was the alternative but that method saturates near ±90° since it reads gravity projection, not the physics state.