### PR TITLE
Fix mod load crash when Nature's Compass is absent

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/naturescompass/NaturesCompassCompatibility.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/naturescompass/NaturesCompassCompatibility.java
@@ -1,17 +1,11 @@
 package dev.simulated_team.simulated.compat.naturescompass;
 
-import com.chaosthedude.naturescompass.NaturesCompass;
-import dev.simulated_team.simulated.Simulated;
 import dev.simulated_team.simulated.service.SimModCompatibilityService;
 
 public class NaturesCompassCompatibility implements SimModCompatibilityService {
 	@Override
 	public void init() {
-		registerTarget();
-	}
-
-	private static void registerTarget() {
-		Simulated.getRegistrate().navTarget("natures_compass", NaturesCompassNavigationTarget::new, () -> NaturesCompass.naturesCompass);
+		NaturesCompassIntegration.register();
 	}
 
 	@Override

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/naturescompass/NaturesCompassIntegration.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/naturescompass/NaturesCompassIntegration.java
@@ -1,0 +1,12 @@
+package dev.simulated_team.simulated.compat.naturescompass;
+
+import com.chaosthedude.naturescompass.NaturesCompass;
+import dev.simulated_team.simulated.Simulated;
+
+// Isolates Nature's Compass class references away from NaturesCompassCompatibility so that
+// ServiceLoader.getConstructor can reflect on the compat class when the mod is absent.
+class NaturesCompassIntegration {
+	static void register() {
+		Simulated.getRegistrate().navTarget("natures_compass", NaturesCompassNavigationTarget::new, () -> NaturesCompass.naturesCompass);
+	}
+}


### PR DESCRIPTION
`NaturesCompassCompatibility` had a lambda over `NaturesCompass.naturesCompass`, which compiled into a synthetic method whose return type is `NaturesCompassItem`. `ServiceLoader.getConstructor(NaturesCompassCompatibility.class)` resolves synthetic method signatures during reflection, so when the mod is absent the class fails to load and throws `NoClassDefFoundError` from inside `iterator.hasNext()`. That call sits outside the existing try/catch in `SimModCompatibilityService.initLoaded`, so mod init aborts.

Move the NC-touching lambda to a separate `NaturesCompassIntegration` class. `NaturesCompassCompatibility` now has no NC references in its constant pool; reflection succeeds whether or not the mod is installed. `NaturesCompassIntegration` is only class-loaded when `init()` actually runs, which the `isLoaded(modId)` guard already restricts to the NC-present case.

Verified empirically: pre-fix reproduces the exact `NoClassDefFoundError: com/chaosthedude/naturescompass/items/NaturesCompassItem` from the linked issues; post-fix reflection + `getModId()` succeed with Minecraft classes on the classpath and no Nature's Compass jar.

Closes #218, #203, #274.