### PR TITLE
Fix optical_sensor no-hit detection on CC and display source

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/OpticalSensorPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/OpticalSensorPeripheral.java
@@ -16,6 +16,11 @@ public class OpticalSensorPeripheral extends SimPeripheral<OpticalSensorBlockEnt
     }
 
     @LuaFunction
+    public boolean hasHit() {
+        return this.blockEntity.hasHit();
+    }
+
+    @LuaFunction
     public float getDistance() {
         return this.blockEntity.getHitBlockDistance();
     }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/OpticalSensorPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/OpticalSensorPeripheral.java
@@ -29,4 +29,14 @@ public class OpticalSensorPeripheral extends SimPeripheral<OpticalSensorBlockEnt
     public String getBlock() {
         return BuiltInRegistries.BLOCK.getKey(this.blockEntity.getHitBlock()).toString();
     }
+
+    @LuaFunction
+    public float getRange() {
+        return this.blockEntity.getLaserRange();
+    }
+
+    @LuaFunction(mainThread = true)
+    public final void setRange(final int blocks) {
+        this.blockEntity.setRange(blocks);
+    }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/lasers/optical_sensor/OpticalSensorBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/lasers/optical_sensor/OpticalSensorBlockEntity.java
@@ -163,6 +163,12 @@ public class OpticalSensorBlockEntity extends AbstractLaserBlockEntity implement
         return this.range.getValue() + 1;
     }
 
+    public void setRange(final int blocks) {
+        final int max = SimConfigService.INSTANCE.server().blocks.opticalSensorRange.get();
+        // getLaserRange = scroll.getValue() + 1, so translate the caller's "block reach" back to scroll units.
+        this.range.setValue(Math.clamp(blocks - 1, 1, max));
+    }
+
     public float getRayDistance() {
        return this.rayDistance;
     }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/lasers/optical_sensor/OpticalSensorBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/lasers/optical_sensor/OpticalSensorBlockEntity.java
@@ -67,10 +67,16 @@ public class OpticalSensorBlockEntity extends AbstractLaserBlockEntity implement
     }
 
     public float getHitBlockDistance() {
+        if (this.hitBlock.defaultBlockState().isAir()) {
+            return this.getLaserRange();
+        }
         final Vector3dc pos = Sable.HELPER.projectOutOfSubLevel(this.getLevel(), JOMLConversion.atCenterOf(this.getBlockPos()));
         final Vector3dc hitPos = Sable.HELPER.projectOutOfSubLevel(this.getLevel(), JOMLConversion.toJOML(this.laser.getBlockHitResult().getLocation()));
+        return (float) pos.distance(hitPos);
+    }
 
-        return this.hitBlock.defaultBlockState().isAir() ? 15 : (float) pos.distance(hitPos);
+    public boolean hasHit() {
+        return !this.hitBlock.defaultBlockState().isAir();
     }
 
     public OpticalSensorBlockEntity(final BlockEntityType<?> type, final BlockPos pos, final BlockState state) {

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/display_sources/OpticalSensorDisplaySource.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/display_sources/OpticalSensorDisplaySource.java
@@ -7,7 +7,6 @@ import com.simibubi.create.foundation.gui.ModularGuiLineBuilder;
 import dev.simulated_team.simulated.content.blocks.lasers.optical_sensor.OpticalSensorBlockEntity;
 import dev.simulated_team.simulated.data.SimLang;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.world.level.block.Blocks;
 
 public class OpticalSensorDisplaySource extends NumericSingleLineDisplaySource {
 
@@ -19,21 +18,17 @@ public class OpticalSensorDisplaySource extends NumericSingleLineDisplaySource {
 
         switch (context.sourceConfig().getInt("OpticalSensorSelection")) {
             case 0 -> {
-                return be.getHitBlock() == Blocks.AIR ?
-                        SimLang.text("No Block Detected")
-                                .component() :
-                        be.getHitBlock().getName();
+                return be.hasHit() ? be.getHitBlock().getName() : SimLang.text("No Block Detected").component();
             }
             case 1 -> {
+                if (!be.hasHit()) {
+                    return SimLang.text("No Block Detected").component();
+                }
                 final float rayDistance = be.getRayDistance();
-                return rayDistance > be.getLaserRange() ?
-                        SimLang.text("No Block Detected")
-                                .component() :
-
-                        SimLang.number(rayDistance)
-                                .space()
-                                .text("block" + (rayDistance != 1 ? "s" : ""))
-                                .component();
+                return SimLang.number(rayDistance)
+                        .space()
+                        .text("block" + (rayDistance != 1 ? "s" : ""))
+                        .component();
             }
         }
 


### PR DESCRIPTION
Two related bugs in the optical_sensor's miss-case:

**CC peripheral** — `getDistance()` returned literal `15` on miss (a magic constant leaked from the redstone signal-strength scale). Lua consumers couldn't tell "hit at 15 m" from "no hit at all," and a sensor configured for e.g. 32 m range still reported 15 in open space. Fixed to return the configured range on miss. Added `hasHit()` as an explicit boolean companion so Lua can disambiguate without having to compare against the range.

**Display source (Block Distance mode)** — the `rayDistance > getLaserRange()` guard was dead code: `rayDistance` is capped at `getLaserRange()` upstream, so the guard could never fire. The second display mode therefore always showed the distance number, never "No Block Detected." Fixed to use `hasHit()` like mode 0 (Detected Block) already does. Both modes now behave consistently.

Also switches mode 0 to use `hasHit()` instead of `getHitBlock() == Blocks.AIR` for a single source of truth. No behavior change (both are equivalent), just a cleanup.