### PR TITLE
Add Explorer's Compass compatibility

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -76,6 +76,7 @@ if (project.path.endsWith(":common")) {
         // Mod compat
         compileOnly("cc.tweaked:cc-tweaked-$minecraft_version-common-api:$computercraft_tweaked_version")
         compileOnly("maven.modrinth:natures-compass:$minecraft_version-$natures_compass_version-neoforge")
+        compileOnly("maven.modrinth:explorers-compass:$minecraft_version-$explorers_compass_version-neoforge")
         compileOnly("maven.modrinth:sodium:$sodium_version")
         compileOnly("maven.modrinth:iris:$iris_version")
     }

--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -49,6 +49,7 @@ dependencies {
     runtimeOnly("cc.tweaked:cc-tweaked-$minecraft_version-forge:$computercraft_tweaked_version")
 
     implementation("maven.modrinth:natures-compass:$minecraft_version-$natures_compass_version-neoforge")
+    implementation("maven.modrinth:explorers-compass:$minecraft_version-$explorers_compass_version-neoforge")
     compileOnly("maven.modrinth:iris:$iris_version")
     compileOnly("maven.modrinth:sodium:$rootProject.sodium_version")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,6 +47,7 @@ jei_version = 19.21.0.247
 # Mod Integration
 computercraft_tweaked_version = 1.115.1
 natures_compass_version = 3.4.0
+explorers_compass_version = 3.4.0
 curios_version=9.2.2
 sodium_version=mc1.21.1-0.6.13-neoforge
 iris_version=1.8.12+1.21.1-neoforge

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/explorerscompass/ExplorersCompassCompatibility.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/explorerscompass/ExplorersCompassCompatibility.java
@@ -1,0 +1,15 @@
+package dev.simulated_team.simulated.compat.explorerscompass;
+
+import dev.simulated_team.simulated.service.SimModCompatibilityService;
+
+public class ExplorersCompassCompatibility implements SimModCompatibilityService {
+	@Override
+	public void init() {
+		ExplorersCompassRegistry.init();
+	}
+
+	@Override
+	public String getModId() {
+		return "explorerscompass";
+	}
+}

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/explorerscompass/ExplorersCompassNavigationTarget.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/explorerscompass/ExplorersCompassNavigationTarget.java
@@ -1,0 +1,27 @@
+package dev.simulated_team.simulated.compat.explorerscompass;
+
+import com.chaosthedude.explorerscompass.ExplorersCompass;
+import dev.simulated_team.simulated.content.blocks.nav_table.NavTableBlockEntity;
+import dev.simulated_team.simulated.content.blocks.nav_table.navigation_target.NavigationTarget;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+public class ExplorersCompassNavigationTarget implements NavigationTarget {
+	@Override
+	public @Nullable Vec3 getTarget(final NavTableBlockEntity navBE, final ItemStack self) {
+		final Integer x = self.getComponents().get(ExplorersCompass.FOUND_X_COMPONENT);
+		final Integer z = self.getComponents().get(ExplorersCompass.FOUND_Z_COMPONENT);
+		if (x != null && z != null) {
+			final Vec3 pos = navBE.getProjectedSelfPos();
+			return new Vec3(x, pos.y(), z);
+		}
+
+		return null;
+	}
+
+	@Override
+	public float getMaxRange() {
+		return 0;
+	}
+}

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/explorerscompass/ExplorersCompassRegistry.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/explorerscompass/ExplorersCompassRegistry.java
@@ -1,0 +1,10 @@
+package dev.simulated_team.simulated.compat.explorerscompass;
+
+import com.chaosthedude.explorerscompass.ExplorersCompass;
+import dev.simulated_team.simulated.Simulated;
+
+public class ExplorersCompassRegistry {
+    public static void init() {
+        Simulated.getRegistrate().navTarget("explorers_compass", ExplorersCompassNavigationTarget::new, () -> ExplorersCompass.explorersCompass);
+    }
+}

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/index/SimTags.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/index/SimTags.java
@@ -91,6 +91,8 @@ public class SimTags {
             prov.tag(ROTATE_WITH_NAV_ARROW)
                     .add(COMPASS, RECOVERY_COMPASS)
                     .addOptional(ResourceLocation.fromNamespaceAndPath("naturescompass", "naturescompass"));
+            prov.tag(ROTATE_WITH_NAV_ARROW)
+                    .addOptional(ResourceLocation.fromNamespaceAndPath("explorerscompass", "explorerscompass"));
             prov.tag(DESTROYS_ROPE)
                     .add(SHEARS)
                     .add(AllItems.WRENCH.asItem());

--- a/simulated/common/src/main/resources/META-INF/services/dev.simulated_team.simulated.service.SimModCompatibilityService
+++ b/simulated/common/src/main/resources/META-INF/services/dev.simulated_team.simulated.service.SimModCompatibilityService
@@ -1,2 +1,3 @@
 dev.simulated_team.simulated.compat.computercraft.ComputerCraftPeripherals
 dev.simulated_team.simulated.compat.naturescompass.NaturesCompassCompatibility
+dev.simulated_team.simulated.compat.explorerscompass.ExplorersCompassCompatibility


### PR DESCRIPTION
Adds a `NavigationTarget` for Explorer's Compass. Behaves like the existing Nature's Compass compat: when the compass has found a structure, the nav table points to it.

Uses the same three-layer isolation as the Nature's Compass compat so it can't NCDFE on absent classpath.