### PR TITLE
CC: Tweaked Events - Typewriter

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/AttachedComputerHandler.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/AttachedComputerHandler.java
@@ -1,0 +1,21 @@
+package dev.simulated_team.simulated.compat.computercraft;
+
+import dan200.computercraft.api.peripheral.AttachedComputerSet;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import org.jspecify.annotations.Nullable;
+
+public class AttachedComputerHandler {
+    private final AttachedComputerSet attachedComputers = new AttachedComputerSet();
+
+    public void attach(IComputerAccess computer) {
+        this.attachedComputers.add(computer);
+    }
+
+    public void detach(IComputerAccess computer) {
+        this.attachedComputers.remove(computer);
+    }
+
+    public void queueEvent(String event, @Nullable Object... args) {
+        this.attachedComputers.queueEvent(event, args);
+    }
+}

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/AttachedComputerHandler.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/AttachedComputerHandler.java
@@ -5,6 +5,7 @@ import dan200.computercraft.api.peripheral.IComputerAccess;
 import org.jspecify.annotations.Nullable;
 
 public class AttachedComputerHandler {
+
     private final AttachedComputerSet attachedComputers = new AttachedComputerSet();
 
     public void attach(IComputerAccess computer) {

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/LinkedTypewriterPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/LinkedTypewriterPeripheral.java
@@ -20,14 +20,12 @@ public class LinkedTypewriterPeripheral extends SimPeripheral<LinkedTypewriterBl
     @Override
     public void attach(IComputerAccess computer) {
         super.attach(computer);
-        System.out.println("Attaching linked typewriter block entity");
         this.blockEntity.computerHandler.attach(computer);
     }
 
     @Override
     public void detach(IComputerAccess computer) {
         super.detach(computer);
-        System.out.println("Detaching linked typewriter block entity");
         this.blockEntity.computerHandler.detach(computer);
     }
 

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/LinkedTypewriterPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/LinkedTypewriterPeripheral.java
@@ -1,6 +1,7 @@
 package dev.simulated_team.simulated.compat.computercraft.peripherals;
 
 import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.peripheral.IComputerAccess;
 import dev.simulated_team.simulated.content.blocks.redstone.linked_typewriter.LinkedTypewriterBlockEntity;
 
 import java.util.List;
@@ -14,6 +15,20 @@ public class LinkedTypewriterPeripheral extends SimPeripheral<LinkedTypewriterBl
     @Override
     public String getType() {
         return "linked_typewriter";
+    }
+
+    @Override
+    public void attach(IComputerAccess computer) {
+        super.attach(computer);
+        System.out.println("Attaching linked typewriter block entity");
+        this.blockEntity.computerHandler.attach(computer);
+    }
+
+    @Override
+    public void detach(IComputerAccess computer) {
+        super.detach(computer);
+        System.out.println("Detaching linked typewriter block entity");
+        this.blockEntity.computerHandler.detach(computer);
     }
 
     @LuaFunction

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/linked_typewriter/LinkedTypewriterBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/linked_typewriter/LinkedTypewriterBlockEntity.java
@@ -4,11 +4,17 @@ import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.content.equipment.clipboard.ClipboardCloneable;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
+import dan200.computercraft.api.peripheral.AttachedComputerSet;
 import dev.ryanhcode.sable.Sable;
+import dev.simulated_team.simulated.compat.computercraft.AttachedComputerHandler;
 import dev.simulated_team.simulated.content.blocks.redstone.linked_typewriter.screen.LinkedTypewriterMenuCommon;
 import dev.simulated_team.simulated.index.SimBlocks;
 import dev.simulated_team.simulated.index.SimSoundEvents;
 import dev.simulated_team.simulated.mixin_interface.PlayerTypewriterExtension;
+import dev.simulated_team.simulated.service.ServiceUtil;
+import dev.simulated_team.simulated.service.SimModCompatibilityService;
+import dev.simulated_team.simulated.service.SimPlatformService;
+import net.createmod.catnip.platform.services.PlatformHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -38,6 +44,7 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
     private String typedEntry = "";
 
     public boolean powered;
+    public final AttachedComputerHandler computerHandler = new AttachedComputerHandler();
 
     public LinkedTypewriterBlockEntity(final BlockEntityType<?> type, final BlockPos pos, final BlockState state) {
         super(type, pos, state);
@@ -181,6 +188,8 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
         if (this.typedEntry.length() >= 25) {
             this.typedEntry = this.typedEntry.substring(1);
         }
+        if (SimPlatformService.INSTANCE.isLoaded("computercraft"))
+            this.computerHandler.queueEvent("key", key, entryMap.getEntry(key).isAlive());
         this.entryMap.activateKey(key, this);
     }
 
@@ -190,6 +199,8 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
     public void releaseKey(final int key) {
         this.pressedKeys.remove((Integer) key);
         this.entryMap.deactivateKey(key);
+        if (SimPlatformService.INSTANCE.isLoaded("computercraft"))
+            this.computerHandler.queueEvent("key_up", key);
     }
 
     @Override

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/linked_typewriter/LinkedTypewriterBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/linked_typewriter/LinkedTypewriterBlockEntity.java
@@ -44,11 +44,15 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
     private String typedEntry = "";
 
     public boolean powered;
-    public final AttachedComputerHandler computerHandler = new AttachedComputerHandler();
+    public final AttachedComputerHandler computerHandler;
 
     public LinkedTypewriterBlockEntity(final BlockEntityType<?> type, final BlockPos pos, final BlockState state) {
         super(type, pos, state);
         this.entryMap = new LinkedTypewriterEntries();
+        if (SimPlatformService.INSTANCE.isLoaded("computercraft"))
+            computerHandler = new AttachedComputerHandler();
+        else
+            computerHandler = null;
     }
 
     @Override

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/linked_typewriter/LinkedTypewriterBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/linked_typewriter/LinkedTypewriterBlockEntity.java
@@ -4,17 +4,13 @@ import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.content.equipment.clipboard.ClipboardCloneable;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
-import dan200.computercraft.api.peripheral.AttachedComputerSet;
 import dev.ryanhcode.sable.Sable;
 import dev.simulated_team.simulated.compat.computercraft.AttachedComputerHandler;
 import dev.simulated_team.simulated.content.blocks.redstone.linked_typewriter.screen.LinkedTypewriterMenuCommon;
 import dev.simulated_team.simulated.index.SimBlocks;
 import dev.simulated_team.simulated.index.SimSoundEvents;
 import dev.simulated_team.simulated.mixin_interface.PlayerTypewriterExtension;
-import dev.simulated_team.simulated.service.ServiceUtil;
-import dev.simulated_team.simulated.service.SimModCompatibilityService;
 import dev.simulated_team.simulated.service.SimPlatformService;
-import net.createmod.catnip.platform.services.PlatformHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -31,12 +27,13 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements MenuProvider, ClipboardCloneable {
+
+    private static final boolean CC_LOADED = SimPlatformService.INSTANCE.isLoaded("computercraft");
 
     private LinkedTypewriterEntries entryMap;
     private final List<Integer> pressedKeys = new ArrayList<>();
@@ -49,10 +46,11 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
     public LinkedTypewriterBlockEntity(final BlockEntityType<?> type, final BlockPos pos, final BlockState state) {
         super(type, pos, state);
         this.entryMap = new LinkedTypewriterEntries();
-        if (SimPlatformService.INSTANCE.isLoaded("computercraft"))
-            computerHandler = new AttachedComputerHandler();
-        else
-            computerHandler = null;
+        if (CC_LOADED) {
+            this.computerHandler = new AttachedComputerHandler();
+        } else {
+            this.computerHandler = null;
+        }
     }
 
     @Override
@@ -105,7 +103,7 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
                 this.currentUser = userID;
                 final BlockPos previousTypewriter = player.simulated$getCurrentTypewriter();
                 if (previousTypewriter != null) {
-                    if (this.level.getBlockEntity(previousTypewriter) instanceof final LinkedTypewriterBlockEntity nbe && nbe != this) {
+                    if (this.level.getBlockEntity(previousTypewriter) instanceof final LinkedTypewriterBlockEntity nbe) {
                         nbe.disconnectUser();
                     }
                 }
@@ -192,8 +190,9 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
         if (this.typedEntry.length() >= 25) {
             this.typedEntry = this.typedEntry.substring(1);
         }
-        if (SimPlatformService.INSTANCE.isLoaded("computercraft"))
+        if (this.computerHandler != null) {
             this.computerHandler.queueEvent("key", key, entryMap.getEntry(key).isAlive());
+        }
         this.entryMap.activateKey(key, this);
     }
 
@@ -203,8 +202,9 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
     public void releaseKey(final int key) {
         this.pressedKeys.remove((Integer) key);
         this.entryMap.deactivateKey(key);
-        if (SimPlatformService.INSTANCE.isLoaded("computercraft"))
+        if (this.computerHandler != null) {
             this.computerHandler.queueEvent("key_up", key);
+        }
     }
 
     @Override
@@ -277,8 +277,9 @@ public class LinkedTypewriterBlockEntity extends SmartBlockEntity implements Men
 
     @Override
     public boolean readFromClipboard(final HolderLookup.@NotNull Provider registries, final CompoundTag tag, final Player player, final Direction side, final boolean simulate) {
-        if (simulate)
+        if (simulate) {
             return true;
+        }
         this.entryMap = LinkedTypewriterEntries.readKeys(registries, tag.getList("Keys", 10), this.getBlockPos());
         return true;
     }


### PR DESCRIPTION
Typewriters now fire `key` and `key_up` events when their peripheral is attached to any computer

This is done via a new `AttachedComputerHandler` class that is really a wrapper for `AttachedComputerSet` so that the `LinkedTypewriterBlockEntity` class did not load any CC: Tweaked classes

The BE starts with a new `AttachedComputerHandler` instance as a public final field (so the peripheral can access it), then, when `pressKey` or `releaseKey` is called, if ComputerCraft is loaded, `AttachedComputerHandler#queueEvent` is called, which will queue the relevant event for any attached computers

As for the peripheral side, `attach` and `detach` have been overridden and call `AttachedComputerHandler#attach` and `AttachedComputerHandler#detach` respectively