### PR TITLE
Fix PonderPlugin.

### DIFF
--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/ponder/AeroPonderPlugin.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/ponder/AeroPonderPlugin.java
@@ -1,7 +1,6 @@
 package dev.eriksonn.aeronautics.content.ponder;
 
 import com.simibubi.create.foundation.ponder.CreatePonderPlugin;
-import com.simibubi.create.foundation.ponder.PonderWorldBlockEntityFix;
 import dev.eriksonn.aeronautics.Aeronautics;
 import dev.eriksonn.aeronautics.index.AeroPonderScenes;
 import net.createmod.ponder.api.level.PonderLevel;
@@ -36,7 +35,7 @@ public class AeroPonderPlugin extends CreatePonderPlugin {
 
     @Override
     public void onPonderLevelRestore(final PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
+
     }
 
     @Override

--- a/offroad/common/src/main/java/dev/ryanhcode/offroad/content/ponder/OffroadPonderPlugin.java
+++ b/offroad/common/src/main/java/dev/ryanhcode/offroad/content/ponder/OffroadPonderPlugin.java
@@ -1,7 +1,6 @@
 package dev.ryanhcode.offroad.content.ponder;
 
 import com.simibubi.create.foundation.ponder.CreatePonderPlugin;
-import com.simibubi.create.foundation.ponder.PonderWorldBlockEntityFix;
 import dev.ryanhcode.offroad.Offroad;
 import dev.ryanhcode.offroad.index.OffroadPonderScenes;
 import net.createmod.ponder.api.level.PonderLevel;
@@ -36,7 +35,7 @@ public class OffroadPonderPlugin extends CreatePonderPlugin {
 
     @Override
     public void onPonderLevelRestore(final PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
+
     }
 
     @Override

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/index/ponder/SimPonderPlugin.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/index/ponder/SimPonderPlugin.java
@@ -1,7 +1,6 @@
 package dev.simulated_team.simulated.index.ponder;
 
 import com.simibubi.create.foundation.ponder.CreatePonderPlugin;
-import com.simibubi.create.foundation.ponder.PonderWorldBlockEntityFix;
 import dev.simulated_team.simulated.Simulated;
 import dev.simulated_team.simulated.index.SimPonderScenes;
 import dev.simulated_team.simulated.index.SimPonderTags;
@@ -44,7 +43,7 @@ public class SimPonderPlugin extends CreatePonderPlugin {
 
     @Override
     public void onPonderLevelRestore(final PonderLevel ponderLevel) {
-        PonderWorldBlockEntityFix.fixControllerBlockEntities(ponderLevel);
+
     }
 
     @Override


### PR DESCRIPTION
`ModPonderPlugin#onPonderLevelRestore` calls `PonderWorldBlockEntityFix#fixControllerBlockEntities`, which causes controller BE position being adjusted more then once. Because `PonderWorldBlockEntityFix#fixControllerBlockEntities` is applied globally instead of seperately and already been called by `CreatePonderPlugin`.

This should fix https://github.com/Creators-of-Aeronautics/Simulated-Project/issues/313 and 
https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/342#issuecomment-4291453381