### PR TITLE
Fix Rope Item not playing placement sound

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/items/rope/RopeItem/RopeItem.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/items/rope/RopeItem/RopeItem.java
@@ -120,6 +120,7 @@ public class RopeItem extends Item {
 
         if (ropeHolderA.createRope(ropeHolderB)) {
             level.playSound(null, posA, SoundEvents.WOOL_PLACE, SoundSource.BLOCKS, 0.5F, 1F);
+            level.playSound(null, posB, SoundEvents.WOOL_PLACE, SoundSource.BLOCKS, 0.5F, 1F);
             return true;
         }
         return false;


### PR DESCRIPTION
Rope item only plays sound at `posA` (origin) which is usually very far from `posB` (second rope connector player actually clicks to create rope)