### PR TITLE
Fixes a null pointer crash in MapNavigationTarget

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/navigation_targets/MapNavigationTarget.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/navigation_targets/MapNavigationTarget.java
@@ -47,13 +47,15 @@ public class MapNavigationTarget implements NavigationTarget {
 			}
 
 			final MapItemSavedData mapData = level.getMapData(mapId);
-			final Collection<MapBanner> banners = mapData.getBanners();
-			for (final MapBanner banner : banners) {
-				final Vec3 bannerPos = banner.pos().getCenter();
-				final double dist = pos.distanceToSqr(bannerPos.x(), pos.y(), bannerPos.z());
-				if(dist < closestDist) {
-					closestPos = bannerPos;
-					closestDist = dist;
+			if (mapData != null) {
+				final Collection<MapBanner> banners = mapData.getBanners();
+				for (final MapBanner banner : banners) {
+					final Vec3 bannerPos = banner.pos().getCenter();
+					final double dist = pos.distanceToSqr(bannerPos.x(), pos.y(), bannerPos.z());
+					if(dist < closestDist) {
+						closestPos = bannerPos;
+						closestDist = dist;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes a null pointer crash in `MapNavigationTarget` when a nav table contains a map whose `MapItemSavedData` is
  missing in the current world.

  This can happen when a nav table is saved in a Create blueprint/schematic and later placed in another world. The
  copied map item may still contain a `MapId`, but that ID does not exist in the new world, so `level.getMapData(mapId)`
  returns `null`.