### PR TITLE
Fix: handle nullable rope attachment

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
@@ -47,7 +47,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
@@ -133,7 +132,10 @@ public class RopeStrandHolderBehavior extends BlockEntityBehaviour {
 
             if (alreadyTrackingPlayers.add(uuid)) {
                 this.ownedServerStrand.updatePose();
-                VeilPacketManager.player(player).sendPacket(this.makeUpdatePacket());
+                final ClientboundRopeDataPacket packet = this.makeUpdatePacket();
+                if (packet != null) {
+                    VeilPacketManager.player(player).sendPacket(packet);
+                }
             }
         }
     }
@@ -156,22 +158,26 @@ public class RopeStrandHolderBehavior extends BlockEntityBehaviour {
         return level.getChunkSource().chunkMap.getPlayers(chunk, false);
     }
 
-    @NotNull
+    @Nullable
     public ClientboundRopeDataPacket makeUpdatePacket() {
         final ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(this.getLevel());
         assert container != null;
 
         final SubLevelTrackingSystem trackingSystem = container.trackingSystem();
 
-        //todo can be null from schematics
-        final RopeAttachment startAttachment = this.ownedServerStrand.getAttachment(RopeAttachmentPoint.START);
-        final RopeAttachment endAttachment = this.ownedServerStrand.getAttachment(RopeAttachmentPoint.END);
+        final ServerRopeStrand strand = this.ownedServerStrand != null ? this.ownedServerStrand : this.getAttachedStrand();
+        if (strand == null) {
+            return null;
+        }
+
+        final RopeAttachment startAttachment = strand.getAttachment(RopeAttachmentPoint.START);
+        final RopeAttachment endAttachment = strand.getAttachment(RopeAttachmentPoint.END);
 
         return new ClientboundRopeDataPacket(
                 trackingSystem.getInterpolationTick(),
                 this.blockEntity.getBlockPos(),
-                this.ownedServerStrand.getUUID(),
-                new ObjectArrayList<>(this.ownedServerStrand.getPoints()),
+                strand.getUUID(),
+                new ObjectArrayList<>(strand.getPoints()),
                 startAttachment != null ? startAttachment.blockAttachment() : null,
                 endAttachment != null ? endAttachment.blockAttachment() : null
         );

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/strand/server/ServerRopeStrand.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/strand/server/ServerRopeStrand.java
@@ -154,6 +154,9 @@ public class ServerRopeStrand extends RopePhysicsObject {
         assert container != null;
 
         final RopeAttachment attachment = this.attachments.get(RopeAttachmentPoint.START);
+        if (attachment == null) {
+            return false;
+        }
         final UUID subLevelID = attachment.subLevelID();
 
         if (subLevelID != null) {

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/strand/server/ServerRopeTrackingSystem.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/strand/server/ServerRopeTrackingSystem.java
@@ -2,6 +2,7 @@ package dev.simulated_team.simulated.content.blocks.rope.strand.server;
 
 import dev.ryanhcode.sable.api.sublevel.SubLevelTrackingPlugin;
 import dev.simulated_team.simulated.content.blocks.rope.RopeStrandHolderBehavior;
+import dev.simulated_team.simulated.network.packets.rope.ClientboundRopeDataPacket;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -75,7 +76,10 @@ public class ServerRopeTrackingSystem implements SubLevelTrackingPlugin {
                     continue;
                 }
 
-                holder.getStrandPacketSink().sendPacket(holder.makeUpdatePacket());
+                final ClientboundRopeDataPacket packet = holder.makeUpdatePacket();
+                if (packet != null) {
+                    holder.getStrandPacketSink().sendPacket(packet);
+                }
                 strand.justSynced();
             } else if (!strand.networkingStopped) {
                 strand.networkingStopped = true;


### PR DESCRIPTION
Fixed this issue: https://github.com/Creators-of-Aeronautics/Simulated-Project/issues/713

## Copilot summary:
This pull request introduces several defensive improvements to the rope synchronization logic, ensuring that null strands are handled gracefully and preventing potential crashes during packet sending. The main changes focus on adding null checks and updating method annotations to reflect possible null returns.

### Defensive programming and null handling

* Updated `makeUpdatePacket()` in `RopeStrandHolderBehavior` to return `null` if the rope strand is unavailable, and changed its annotation from `@NotNull` to `@Nullable`. Callers now check for `null` before sending packets, preventing null pointer exceptions. [[1]](diffhunk://#diff-21afb57a74fd51f43c8310ba3f15d721b84dd059bee5115ca728268eac3150b8L159-R180) [[2]](diffhunk://#diff-21afb57a74fd51f43c8310ba3f15d721b84dd059bee5115ca728268eac3150b8L136-R138) [[3]](diffhunk://#diff-343c749b7dbdfdb39fc41a2b93e8333efa21224a8268df4f1f6cbb781311d66dL78-R82)
* Updated `isOwnerLoaded()` in `ServerRopeStrand` to return `false` if the start attachment is missing, avoiding potential errors when checking the owner's load state.

### Codebase consistency

* Removed an unnecessary import of `@NotNull` and added a missing import for `ClientboundRopeDataPacket` to maintain code clarity and correctness. [[1]](diffhunk://#diff-21afb57a74fd51f43c8310ba3f15d721b84dd059bee5115ca728268eac3150b8L50) [[2]](diffhunk://#diff-343c749b7dbdfdb39fc41a2b93e8333efa21224a8268df4f1f6cbb781311d66dR5)