### PR TITLE
fix: pass explicit classloader to ServiceLoader to fix crash in large modpacks

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/service/ServiceUtil.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/service/ServiceUtil.java
@@ -5,6 +5,6 @@ import java.util.ServiceLoader;
 public class ServiceUtil {
 
 	public static <T> T load(final Class<T> tClass) {
-		return ServiceLoader.load(tClass).findFirst().orElseThrow(() -> new RuntimeException("Unable to find %s implementation".formatted(tClass.getName())));
+		return ServiceLoader.load(tClass, tClass.getClassLoader()).findFirst().orElseThrow(() -> new RuntimeException("Unable to find %s implementation".formatted(tClass.getName())));
 	}
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/service/SimModCompatibilityService.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/service/SimModCompatibilityService.java
@@ -24,7 +24,7 @@ public interface SimModCompatibilityService {
 
     @ApiStatus.Internal
     static void initLoaded() {
-        final ServiceLoader<SimModCompatibilityService> loader = ServiceLoader.load(SimModCompatibilityService.class);
+        final ServiceLoader<SimModCompatibilityService> loader = ServiceLoader.load(SimModCompatibilityService.class, SimModCompatibilityService.class.getClassLoader());
         final Iterator<SimModCompatibilityService> iterator = loader.iterator();
 
         while (iterator.hasNext()) {


### PR DESCRIPTION
`ServiceUtil.load()` uses `ServiceLoader.load(Class)`, which delegates to
`Thread.currentThread().getContextClassLoader()`. In NeoForge's modular
classloader architecture, this may not have visibility of `META-INF/services`
inside jarJar-nested JARs during parallel mod loading in large modpacks.

The fix passes the interface's own classloader, which always sees its module's
service providers.

Fixes #663
Fixes #703

### Precedent

- [Patchouli PR #818](https://github.com/VazkiiMods/Patchouli/pull/818) — identical fix
- [NeoForge `AddressCheck.java` patch](https://github.com/neoforged/NeoForge/blob/1.21.x/patches/net/minecraft/client/multiplayer/resolver/AddressCheck.java.patch) — NeoForge patches vanilla Minecraft with the same pattern

### Testing

Verified in a 150+ mod NeoForge 1.21.1 pack (21.1.228) that previously crashed
every launch with `Unable to find AeroLevititeService implementation`. Clean
startup after patch, zero ServiceLoader errors in logs.