### PR TITLE
fix: use interface classloader for ServiceLoader lookups

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/service/ServiceUtil.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/service/ServiceUtil.java
@@ -5,6 +5,6 @@ import java.util.ServiceLoader;
 public class ServiceUtil {
 
 	public static <T> T load(final Class<T> tClass) {
-		return ServiceLoader.load(tClass).findFirst().orElseThrow(() -> new RuntimeException("Unable to find %s implementation".formatted(tClass.getName())));
+		return ServiceLoader.load(tClass, tClass.getClassLoader()).findFirst().orElseThrow(() -> new RuntimeException("Unable to find %s implementation".formatted(tClass.getName())));
 	}
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/service/SimModCompatibilityService.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/service/SimModCompatibilityService.java
@@ -24,7 +24,7 @@ public interface SimModCompatibilityService {
 
     @ApiStatus.Internal
     static void initLoaded() {
-        final ServiceLoader<SimModCompatibilityService> loader = ServiceLoader.load(SimModCompatibilityService.class);
+        final ServiceLoader<SimModCompatibilityService> loader = ServiceLoader.load(SimModCompatibilityService.class, SimModCompatibilityService.class.getClassLoader());
         final Iterator<SimModCompatibilityService> iterator = loader.iterator();
 
         while (iterator.hasNext()) {


### PR DESCRIPTION
This change is similar to pull #784, but additionally fixes the SimModCompatibilityService layer.

Technical details are the same as #784.

  Fixes: Issue #663
  Fixes: Issue #703 

Testing: Verified in a 610 mod NeoForge 1.21.1 pack (21.1.228).
  
  Made a new PR as unsure how to contribute to the existing one.