### PR TITLE
Add Curios support for Aviator's Goggles

### DIFF
--- a/aeronautics/common/src/generated/resources/data/curios/tags/item/head.json
+++ b/aeronautics/common/src/generated/resources/data/curios/tags/item/head.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "aeronautics:aviators_goggles"
+  ]
+}


### PR DESCRIPTION
Closes https://github.com/Creators-of-Aeronautics/Simulated-Project/issues/714

Adds Curios compatibility for Aviator's Goggles.

Changes:
- Adds `aeronautics:aviators_goggles` to the Curios `head` item tag.
- Ensures the goggles can be equipped in the Curios head slot like Create's Engineer's Goggles.

This matches Create's existing Curios behavior for `create:goggles`.