### PR TITLE
Fix crash when rotation neighbour list is immutable

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/extra_kinetics/RotationPropagatorMixin.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/extra_kinetics/RotationPropagatorMixin.java
@@ -104,7 +104,7 @@ public abstract class RotationPropagatorMixin {
         }
     }
 
-    @Inject(method = "getPotentialNeighbourLocations", at = @At("TAIL"), remap = false)
+    @Inject(method = "getPotentialNeighbourLocations", at = @At("TAIL"), cancellable = true, remap = false)
     private static void simulated$getExtraKineticsBlockPositions(final KineticBlockEntity be, final CallbackInfoReturnable<List<BlockPos>> cir) {
         final List<BlockPos> list = cir.getReturnValue();
         final List<BlockPos> extraKinetics = new ArrayList<>();
@@ -117,7 +117,13 @@ public abstract class RotationPropagatorMixin {
             }
         }
 
-        list.addAll(extraKinetics);
+        try {
+            list.addAll(extraKinetics);
+        } catch (final UnsupportedOperationException ignored) {
+            final List<BlockPos> mutableList = new ArrayList<>(list);
+            mutableList.addAll(extraKinetics);
+            cir.setReturnValue(mutableList);
+        }
     }
 
     @Unique


### PR DESCRIPTION
## Summary
- Handle immutable return lists in `RotationPropagatorMixin#simulated$getExtraKineticsBlockPositions`
- Preserve the existing mutable-list path and only copy when `addAll` throws `UnsupportedOperationException`
- Fixes a crash seen with Create Big Cannons `cannon_mount` when another rotation propagation mixin returns an immutable neighbour list

## Crash context
The crash happens while ticking `createbigcannons:cannon_mount` with this stack shape:

```text
java.lang.UnsupportedOperationException
    at java.util.ImmutableCollections$AbstractImmutableCollection.addAll
    at com.simibubi.create.content.kinetics.RotationPropagator.handler$...$simulated$getExtraKineticsBlockPositions
```

Observed mod combination:
- Minecraft 1.21.1
- NeoForge 21.1.228
- Create 6.0.10
- Create Big Cannons 5.11.2+mc.1.21.1
- Create Simulated 1.1.3
- Create Unlimited 0.7.1
- Create Offroad 1.1.3

## Testing
- `git diff --check`
- Tried `./gradlew.bat :simulated:common:compileJava --no-daemon --stacktrace`, but dependency resolution failed before compilation because `maven.ryanhcode.dev/private` returned `401 Unauthorized` for `net.neoforged:neoform-runtime:2.0.18`, and the fallback Maven timed out.