### PR TITLE
Fix missing model warnings

### DIFF
--- a/simulated/common/src/main/resources/assets/simulated/models/block/rope_connector/block_horizontal.json
+++ b/simulated/common/src/main/resources/assets/simulated/models/block/rope_connector/block_horizontal.json
@@ -1,5 +1,5 @@
 {
-	"parent": "block",
+	"parent": "block/block",
 	"texture_size": [32, 32],
 	"textures": {
 		"0": "simulated:block/rope_winch/winch",

--- a/simulated/common/src/main/resources/assets/simulated/models/block/rope_connector/block_vertical.json
+++ b/simulated/common/src/main/resources/assets/simulated/models/block/rope_connector/block_vertical.json
@@ -1,5 +1,5 @@
 {
-	"parent": "block",
+	"parent": "block/block",
 	"texture_size": [32, 32],
 	"textures": {
 		"1": "simulated:block/rope_winch/winch",

--- a/simulated/common/src/main/resources/assets/simulated/models/block/rope_connector/knot.json
+++ b/simulated/common/src/main/resources/assets/simulated/models/block/rope_connector/knot.json
@@ -1,7 +1,7 @@
 {
 	"format_version": "1.21.11",
 	"credit": "Made by Farcr",
-	"parent": "block",
+	"parent": "minecraft:block/block",
 	"textures": {
 		"0": "simulated:block/rope_particle",
 		"particle": "simulated:block/rope_particle"


### PR DESCRIPTION
Hello. I discovered that `simulated` throws 3 warnings when loading models. I believe it's because parent model "block" doesn't actually exist. I think what you're looking for is "block/block"
I couldn't see any difference in-game but I figured it should be fixed regardless as it shows up every time.