### PR TITLE
Feat: Make the parallel drag scalar of symmetric sail configurable

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/config/server/physics/SimPhysics.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/config/server/physics/SimPhysics.java
@@ -24,6 +24,8 @@ public class SimPhysics extends ConfigBase {
     public final ConfigFloat physicsStaffAngularStiffness = this.f(10000.0f, 0, Float.MAX_VALUE, "physics_staff_angular_stiffness", SimPhysics.Comments.physicsStaffAngularStiffness);
     public final ConfigFloat physicsStaffAngularDamping = this.f(850.0f, 0, Float.MAX_VALUE, "physics_staff_angular_damping", SimPhysics.Comments.physicsStaffAngularDamping);
 
+    public final ConfigFloat symmetricSailParallelDragScalar = this.f(1.75f, 0.0f, Float.MAX_VALUE, "symmetric_sail_parallel_drag_scalar", Comments.symmetricSailParallelDragScalar);
+
 
     @Override
     public String getName() {
@@ -44,6 +46,8 @@ public class SimPhysics extends ConfigBase {
         private static final String dockingConnectorAngleTolerance = "The angle tolerance in degrees for docking connectors to link";
         private static final String dockingConnectorDistanceTolerance = "The distance tolerance in blocks for docking connectors to link";
         private static final String handleMaxForce = "The maximum force handles are allowed to apply to the contraption they are attached to";
+
+        private static final String symmetricSailParallelDragScalar = "The parallel drag scalar of symmetric sail";
 
         public static String physicsStaffLinearStiffness = "The linear stiffness of the joint motors used to hold sub-levels by the Creative Physics Staff";
         public static String physicsStaffLinearDamping = "The linear damping of the joint motors used to hold sub-levels by the Creative Physics Staff";

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/symmetric_sail/SymmetricSailBlock.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/symmetric_sail/SymmetricSailBlock.java
@@ -37,6 +37,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
+import dev.simulated_team.simulated.service.SimConfigService;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -187,7 +188,7 @@ public class SymmetricSailBlock extends RotatedPillarBlock implements IWrenchabl
 
     @Override
     public float sable$getParallelDragScalar() {
-        return 1.75f;
+        return SimConfigService.INSTANCE.server().physics.symmetricSailParallelDragScalar.getF();
     }
 
     @Override


### PR DESCRIPTION
# Summary
Make the parallel drag scalar of symmetric sail configurable with configuration `symmetric_sail_parallel_drag_scalar` at `simulated-server.toml`

# Detail
The `sable$getParallelDragScalar()` at `simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/symmetric_sail/SymmetricSailBlock.java` was returning 1.75f in a fixed manner. But in many cases, to create a aesthetically pleasing aircraft may need a bigger value to make the rudders smaller. So I made this configure item variable which allows it be configured by the server owner.