### PR TITLE
fix: add isSignalSource() override to GimbalSensorBlock

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/gimbal_sensor/GimbalSensorBlock.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/gimbal_sensor/GimbalSensorBlock.java
@@ -41,6 +41,11 @@ public class GimbalSensorBlock extends Block implements IBE<GimbalSensorBlockEnt
     }
 
 
+    @Override
+    public boolean isSignalSource(final BlockState state) {
+        return true;
+    }
+
     public int getSignal(final BlockState pState, final BlockGetter pLevel, final BlockPos pPos, final Direction side) {
         final GimbalSensorBlockEntity be = this.getBlockEntity(pLevel, pPos);
         if (be == null)


### PR DESCRIPTION
## Summary

`GimbalSensorBlock` implements `CommonRedstoneBlock` and overrides `getSignal()`, but is missing the `isSignalSource(BlockState)` override. This causes incompatibility with **Alternate Current** (a redstone optimization mod), which uses `state.isSignalSource()` as a cache flag — without the override it defaults to `false`, and the sensor's signal is never read.

`AltitudeSensorBlock` (the other `CommonRedstoneBlock` in this project) already has this override.

## Change

Added one method:
```java
@Override
public boolean isSignalSource(final BlockState state) {
    return true;
}
```

## Verification

- ✅ Pure declarative marker — no behavioural change
- ✅ Does not affect `getSignal()` direction logic
- ✅ Consistent with `AltitudeSensorBlock`
- ✅ No side effects on existing functionality

Fixes #924