### PR TITLE
Fix redstone inductor charge/discharge speed

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/redstone_inductor/RedstoneInductorBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/redstone/redstone_inductor/RedstoneInductorBlockEntity.java
@@ -86,7 +86,7 @@ public class RedstoneInductorBlockEntity extends SmartBlockEntity implements IHa
                 // setDischarge(false, level);
             }
 
-            if (this.inputDelay.getValue() != 0 && this.delayTicks > this.inputDelay.getValue()) {
+            if (this.inputDelay.getValue() != 0 && this.delayTicks >= this.inputDelay.getValue()) {
                 this.delayTicks = 0;
 
                 if (tempPower > backSignal) tempPower--;


### PR DESCRIPTION
Instead of inputDelay+1 tick per outputSignal update, only inputDelay amount of ticks.

Reason:
When using e.g. 1t delay, outputSignal would only update every 2t.