### PR TITLE
Fix incompatibility of honey fluid from other mods not being used for honey glue recipe

### DIFF
--- a/simulated/common/src/generated/resources/data/simulated/recipe/filling/honey_glue.json
+++ b/simulated/common/src/generated/resources/data/simulated/recipe/filling/honey_glue.json
@@ -5,9 +5,9 @@
       "item": "create:iron_sheet"
     },
     {
-      "type": "neoforge:single",
+      "type": "neoforge:tag",
       "amount": 500,
-      "fluid": "create:honey"
+      "fluid": "c:honey"
     }
   ],
   "results": [


### PR DESCRIPTION
In the case of other mods with honey fluid existing, but aswell being part of the "c:honey" tag. Make it so you can still spout the honey onto the sheet to produce honey glue.