### PR TITLE
Update TorsionSpringBlockEntity.java

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/torsion_spring/TorsionSpringBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/torsion_spring/TorsionSpringBlockEntity.java
@@ -259,8 +259,7 @@ public class TorsionSpringBlockEntity extends KineticBlockEntity implements Extr
                     this.stopTurning();
                 }
             } else if (!parentStopped && this.currentState == State.STOPPED) {
-                // start rotating if the parent is, and we're stopped
-                final double targetAngle = this.parent.angleInput.getValue() * Math.signum(this.lastSpringSpeed);
+                final double targetAngle = this.parent.angleInput.getValue() * Math.signum(this.parent.getSpeed());
                 this.beginTurnTo(targetAngle);
             }
         }


### PR DESCRIPTION
I fixed Torsion Spring logic!

When you choose bigger value than initial while rotation is still given it will act as expected and increase the angle by the value was added. But when you decrease it you`ll usually get an opposite to that angle which is explained by usage of this.lastSpringSpeed which inverts the rotation direction.

I got this bug while messing around with Torsion Spring peripheral.

I simply changed that to this.parent.getSpeed().

I tested and my fix did work both for CC and manual angle change.

Thanks for you have made dreams come true with Sable and Aeronautics. I`d love to contribute you more!