### PR TITLE
Fix ClassCastException in PhysicsAssemblerGUIHandler

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/physics_assembler/PhysicsAssemblerGUIHandler.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/physics_assembler/PhysicsAssemblerGUIHandler.java
@@ -95,9 +95,7 @@ public class PhysicsAssemblerGUIHandler extends BlockHoldInteraction {
     public boolean activeOnMouseMove(final double yaw, final double pitch) {
         final double scalar = 0.5 - Math.abs(0.5 - animatedValue) + 0.05;
 
-        final PhysicsAssemblerBlockEntity be = (PhysicsAssemblerBlockEntity) SableDistUtil.getClientLevel().getBlockEntity(this.getInteractionPos());
-
-        if (be == null) {
+        if (!(SableDistUtil.getClientLevel().getBlockEntity(this.getInteractionPos()) instanceof PhysicsAssemblerBlockEntity)) {
             return false;
         }
 


### PR DESCRIPTION
Fix ClassCastException in PhysicsAssemblerGUIHandler when interacting
 with the assembler while a ghost block is at its position.

Encountered this bug when testing https://github.com/ryanhcode/sable/pull/966 lol

Steps to reproduce:
- Grab a creative motor in your hand (could be another block or be, I tested with this one)
- Rapidly assemble and disassemble the sub-level until the game inevitably crashes with a ClassCastException