### PR TITLE
Fix crash when optical sensor faces waterlogged block

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/lasers/optical_sensor/OpticalSensorBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/lasers/optical_sensor/OpticalSensorBlockEntity.java
@@ -126,8 +126,8 @@ public class OpticalSensorBlockEntity extends AbstractLaserBlockEntity implement
         final ItemStack filterItem = this.filter.getFilter();
         if (context.getType() != HitResult.Type.MISS) {
             if (!filterItem.isEmpty()) {
-                if(!hitFluid.isEmpty()) {
-                    final Fluid fluidInItem = SimFluidService.INSTANCE.getFluidInItem(filterItem);
+                final Fluid fluidInItem = SimFluidService.INSTANCE.getFluidInItem(filterItem);
+                if (fluidInItem != null && !hitFluid.isEmpty()) {
                     passed = fluidInItem.isSame(hitFluid.getType());
                 } else {
                     passed = !hitBlock.isAir() && this.filter.test(new ItemStack(hitBlock.getBlock()));


### PR DESCRIPTION
`OpticalSensorBlockEntity.checkFilter`: when the filter held a solid item (like stone) and the ray hit a waterlogged block, the code entered the fluid comparison branch because `hitFluid` was non-empty, then crashed on `SimFluidService.getFluidInItem(filterItem).isSame(...)` since the method returns null for non-fluid items.

Now the fluid branch only runs when the filter actually contains a fluid. Solid filters fall through to the regular block test and ignore the water.

This fixes issue #1099.