### PR TITLE
Fix includeStart argument not including the start block

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/util/SimAssemblyHelper.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/util/SimAssemblyHelper.java
@@ -138,7 +138,7 @@ public class SimAssemblyHelper {
             return null;
         }
 
-        final SimAssemblyContraption contraption = new SimAssemblyContraption(includeStart ? null : selfPos, !includeEncasingGlue);
+        final SimAssemblyContraption contraption = new SimAssemblyContraption(selfPos, includeStart, !includeEncasingGlue);
 
         contraption.searchMovedStructure(level, toAssemble);
 

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/util/assembly/SimAssemblyContraption.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/util/assembly/SimAssemblyContraption.java
@@ -55,9 +55,12 @@ public class SimAssemblyContraption {
     private final ObjectOpenHashSet<SuperGlueEntity> glueCache = new ObjectOpenHashSet<>();
     private final ObjectOpenHashSet<HoneyGlueEntity> honeyGlueCache = new ObjectOpenHashSet<>();
 
-    public SimAssemblyContraption(final BlockPos anchor, final boolean ignoreEnclosingGlue) {
-        this.anchor = anchor;
+    public SimAssemblyContraption(final BlockPos selfPos, final boolean includeStart, boolean ignoreEnclosingGlue) {
+        this.anchor = includeStart ? null : selfPos;
         this.ignoreEnclosingGlue = ignoreEnclosingGlue;
+        if (includeStart) {
+            this.blocks.add(selfPos);
+        }
     }
 
     public boolean checkAndCacheGlue(final LevelAccessor level, final BlockPos blockPos, final BlockPos offsetDir) {


### PR DESCRIPTION
Normal physics assembler didnt actually care that the includeStart was broken, since it was brittle and would be assemble anyways

This changes it to make includeStart actually force the inclusion of the start, rather than just soft permitting it