### PR TITLE
Optimize BalloonMap merge scanning

### DIFF
--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/BlockEntityLiftingGasProvider.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/BlockEntityLiftingGasProvider.java
@@ -146,8 +146,8 @@ public interface BlockEntityLiftingGasProvider {
 
                 if (graph.hasBlockAt(unloaded.controllerPos())) {
                     serverBalloon.loadFrom(unloaded);
-                    balloonMap.markDirty();
                     iter.remove();
+                    balloonMap.markDirty();
                     break;
                 }
             }

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/Balloon.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/Balloon.java
@@ -64,19 +64,23 @@ public abstract class Balloon {
         this.recomputeBalloonData();
     }
 
-    public void tick() {
+    public boolean tick() {
+        boolean changed = false;
+
         if (this.assembling) {
             this.rebuildBalloonFromController();
             this.assembling = false;
+            changed = true;
         }
 
-        this.checkHeaters();
+        return this.checkHeaters() || changed;
     }
 
-    protected void checkHeaters() {
+    protected boolean checkHeaters() {
         final Iterator<BlockEntityLiftingGasProvider> iterator = this.heaters.iterator();
 
         BlockPos highestPos = null;
+        boolean changed = false;
 
         final SubLevel balloonSubLevel = Sable.HELPER.getContaining(this.level, this.controllerPos);
         while (iterator.hasNext()) {
@@ -87,6 +91,7 @@ public abstract class Balloon {
             if (!heater.canOutputGas() || heaterPos == null || Sable.HELPER.getContaining(this.level, heaterPos) != balloonSubLevel) {
                 heater.setBalloon(null);
                 iterator.remove();
+                changed = true;
                 continue;
             }
 
@@ -98,18 +103,19 @@ public abstract class Balloon {
         }
 
         if (highestPos != null) {
-            this.moveController(highestPos);
+            changed |= this.moveController(highestPos);
         }
 
-        this.splitHeaters();
+        return this.splitHeaters() || changed;
     }
 
     /**
      * Splits heaters which are controlling blocks outside of this balloon off of this balloon
      * (in-case the region was split, or something of the nature)
      */
-    private void splitHeaters() {
+    private boolean splitHeaters() {
         final Iterator<BlockEntityLiftingGasProvider> iterator = this.heaters.iterator();
+        boolean changed = false;
 
         while (iterator.hasNext()) {
             final BlockEntityLiftingGasProvider heater = iterator.next();
@@ -121,8 +127,11 @@ public abstract class Balloon {
             if (!this.graph.hasBlockAt(heaterPos)) {
                 heater.setBalloon(null);
                 iterator.remove();
+                changed = true;
             }
         }
+
+        return changed;
     }
 
     public void onSolidBlockAdded(final BlockPos pos) {
@@ -293,15 +302,17 @@ public abstract class Balloon {
      * Moves the controller to a new position, rebuilding the region
      * @param newControllerPos the position to move the controller to
      */
-    public void moveController(final BlockPos newControllerPos) {
+    public boolean moveController(final BlockPos newControllerPos) {
         if (this.controllerPos.equals(newControllerPos))
-            return;
+            return false;
 
         final boolean needsRebuild = !Objects.equals(this.graph.getLayerAt(newControllerPos), this.graph.getLayerAt(this.controllerPos));
         this.controllerPos = newControllerPos;
 
         if (needsRebuild)
             this.rebuildBalloonFromController();
+
+        return true;
     }
 
     protected void rebuildBalloonFromController() {

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/ServerBalloon.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/ServerBalloon.java
@@ -17,6 +17,8 @@ import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData
 import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import dev.ryanhcode.sable.util.LevelAccelerator;
 import dev.ryanhcode.sable.util.SableMathUtils;
+import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
+import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
@@ -67,27 +69,8 @@ public class ServerBalloon extends Balloon {
         SableMathUtils.fmaOuterProduct(this.averagePosition, this.averagePosition, -this.getCapacity(), this.translatedOuterProduct);
     }
 
-    protected void checkHeaters() {
-        super.checkHeaters();
-
-        for (final LiftingGasData data : this.gasAmounts.values()) {
-            data.target = 0;
-        }
-
-        if (this.leaking) {
-            return;
-        }
-
-        for (final BlockEntityLiftingGasProvider heater : this.heaters) {
-            this.gasAmounts.compute(heater.getLiftingGasType(), (k, v) -> {
-                if (v == null) {
-                    v = new LiftingGasData();
-                }
-
-                v.target += heater.getGasOutput();
-                return v;
-            });
-        }
+    protected boolean checkHeaters() {
+        return super.checkHeaters();
     }
     static final Vector3d force = new Vector3d();
     static final Vector3d torque = new Vector3d();
@@ -243,13 +226,32 @@ public class ServerBalloon extends Balloon {
         return this.totalTargetVolume > 0.05 || this.totalFilledVolume > 0.05;
     }
 
-    public void tick() {
-        super.tick();
-        this.updateGasAmounts();
+    public boolean tick() {
+        final boolean changed = super.tick();
+        return this.updateGasAmounts() || changed;
     }
 
-    public void updateGasAmounts() {
+    public boolean updateGasAmounts() {
         final int capacity = this.getCapacity();
+        boolean changed = false;
+        final Object2DoubleOpenHashMap<LiftingGasType> targetAmounts = new Object2DoubleOpenHashMap<>();
+
+        if (!this.leaking) {
+            for (final BlockEntityLiftingGasProvider heater : this.heaters) {
+                targetAmounts.addTo(heater.getLiftingGasType(), heater.getGasOutput());
+            }
+        }
+
+        for (final Object2DoubleMap.Entry<LiftingGasType> entry : targetAmounts.object2DoubleEntrySet()) {
+            this.gasAmounts.computeIfAbsent(entry.getKey(), x -> new LiftingGasData());
+        }
+
+        for (final Map.Entry<LiftingGasType, LiftingGasData> entry : this.gasAmounts.entrySet()) {
+            final LiftingGasData data = entry.getValue();
+            final double target = targetAmounts.getDouble(entry.getKey());
+            changed |= Double.compare(data.target, target) != 0;
+            data.target = target;
+        }
 
         // we'll allow the balloon to temporarily be over the capacity
         // so that situations such as nuking half of the balloon won't cause instant changes in lift
@@ -261,11 +263,12 @@ public class ServerBalloon extends Balloon {
         }
 
         // get nudges
-        final double scale = Math.min(capacity / this.totalTargetVolume, 1);
+        final double scale = this.totalTargetVolume > 0 ? Math.min(capacity / this.totalTargetVolume, 1) : 1;
         double totalDesiredVolume = 0;
         for (final Map.Entry<LiftingGasType, LiftingGasData> entry : this.gasAmounts.entrySet()) {
             final LiftingGasData data = entry.getValue();
             final LiftingGasType type = entry.getKey();
+            final double oldNudge = data.nudge;
             final double diff = data.target * scale - data.amount;
             data.nudge = diff > 0 ? diff / type.getFillingTime() : (diff < 0 ? diff / type.getEmptyingTime() : 0);
 
@@ -274,6 +277,7 @@ public class ServerBalloon extends Balloon {
                 data.nudge *= 1 + type.getResponsivenessAdjustmentFactor() / (1 + 3 * x * x);
             }
 
+            changed |= Double.compare(oldNudge, data.nudge) != 0;
             totalDesiredVolume += data.amount + data.nudge;
         }
 
@@ -284,13 +288,16 @@ public class ServerBalloon extends Balloon {
 
         for (final Map.Entry<LiftingGasType, LiftingGasData> entry : this.gasAmounts.entrySet()) {
             final LiftingGasData data = entry.getValue();
+            final double oldAmount = data.amount;
             data.amount += data.nudge;
+            changed |= Double.compare(oldAmount, data.amount) != 0;
             this.totalLift += data.amount * entry.getKey().getLiftStrength();
             this.totalFilledVolume += data.amount;
             this.totalVolumeChange += data.nudge;
         }
 
         this.totalTargetVolume = Math.min(this.totalTargetVolume, capacity);
+        return changed;
     }
 
     @Override

--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/map/BalloonMap.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/map/BalloonMap.java
@@ -3,6 +3,7 @@ package dev.eriksonn.aeronautics.content.blocks.hot_air.balloon.map;
 import dev.eriksonn.aeronautics.content.blocks.hot_air.balloon.Balloon;
 import dev.eriksonn.aeronautics.content.blocks.hot_air.balloon.ServerBalloon;
 import dev.eriksonn.aeronautics.content.blocks.hot_air.balloon.graph.BalloonBuilder;
+import dev.eriksonn.aeronautics.content.blocks.hot_air.balloon.graph.BalloonLayerData;
 import dev.eriksonn.aeronautics.index.AeroTags;
 import dev.ryanhcode.sable.companion.math.BoundingBox3i;
 import dev.ryanhcode.sable.companion.math.BoundingBox3ic;
@@ -10,6 +11,7 @@ import dev.ryanhcode.sable.api.sublevel.SubLevelObserver;
 import dev.ryanhcode.sable.sublevel.SubLevel;
 import dev.ryanhcode.sable.sublevel.plot.LevelPlot;
 import dev.ryanhcode.sable.sublevel.storage.SubLevelRemovalReason;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.*;
 import net.createmod.catnip.data.WorldAttached;
 import net.minecraft.core.BlockPos;
@@ -59,6 +61,7 @@ public class BalloonMap {
      */
     public void addBalloon(final Balloon balloon) {
         this.balloons.add(balloon);
+        this.markDirty();
     }
 
     public void markDirty() {
@@ -74,13 +77,18 @@ public class BalloonMap {
         final boolean newAirtight = newState.is(AeroTags.BlockTags.AIRTIGHT);
 
         if (oldAirtight != newAirtight) {
+            boolean changed = false;
             for (final Balloon balloon : this.getBalloonsNear(blockPos)) {
                 if (newAirtight)
                     balloon.onAirtightBlockAdded(blockPos);
                 else
                     balloon.onAirtightBlockRemoved(blockPos);
+                changed = true;
             }
 
+            if (changed) {
+                this.markDirty();
+            }
             return;
         }
 
@@ -88,11 +96,17 @@ public class BalloonMap {
         final boolean newSolid = BalloonBuilder.isSolid(newState);
 
         if (oldSolid != newSolid) {
+            boolean changed = false;
             for (final Balloon balloon : this.getBalloonsNear(blockPos)) {
                 if (newSolid)
                     balloon.onSolidBlockAdded(blockPos);
                 else
                     balloon.onSolidBlockRemoved(blockPos);
+                changed = true;
+            }
+
+            if (changed) {
+                this.markDirty();
             }
         }
     }
@@ -105,41 +119,114 @@ public class BalloonMap {
             this.initialized = true;
         }
 
-        this.balloons.forEach(Balloon::tick);
-        this.removeBalloons();
-        this.mergeBalloons();
-        this.markDirty();
+        boolean changed = false;
+        for (final Balloon balloon : this.balloons) {
+            changed |= balloon.tick();
+        }
+
+        changed |= this.removeBalloons();
+        changed |= this.mergeBalloons();
+
+        if (changed) {
+            this.markDirty();
+        }
     }
 
     /**
      * Merges balloons that hold heaters that hold eachothers controller positions
      */
-    private void mergeBalloons() {
+    private boolean mergeBalloons() {
+        if (this.balloons.size() < 2) {
+            return false;
+        }
+
+        final Long2ObjectOpenHashMap<ObjectList<Balloon>> controllersByLayerChunk = new Long2ObjectOpenHashMap<>();
+        for (final Balloon balloon : this.balloons) {
+            controllersByLayerChunk.computeIfAbsent(getLayerChunkKey(balloon.getControllerPos()), key -> new ObjectArrayList<>())
+                    .add(balloon);
+        }
+
         final ObjectIterator<Balloon> iter = this.balloons.iterator();
+        boolean changed = false;
 
         while (iter.hasNext()) {
             final Balloon balloon = iter.next();
+            final Balloon otherBalloon = this.findMergeTarget(balloon, controllersByLayerChunk);
 
-            for (final Balloon otherBalloon : this.balloons) {
-                if (balloon == otherBalloon) continue;
+            if (otherBalloon != null) {
+                // the balloons intersect. delightful. we shall nuke the first
+                balloon.onRemoved();
+                otherBalloon.merge(balloon);
+                iter.remove();
+                removeControllerFromIndex(balloon, controllersByLayerChunk);
+                changed = true;
+            }
+        }
 
-                if (balloon.getBounds().intersects(otherBalloon.getBounds()) &&
-                        balloon.getGraph().getLayerAt(otherBalloon.getControllerPos()) != null) {
-                    // the balloons intersect. delightful. we shall nuke the first
-                    balloon.onRemoved();
-                    otherBalloon.merge(balloon);
-                    iter.remove();
-                    break;
+        return changed;
+    }
+
+    @Nullable
+    private Balloon findMergeTarget(final Balloon balloon,
+                                    final Long2ObjectOpenHashMap<ObjectList<Balloon>> controllersByLayerChunk) {
+        for (final List<BalloonLayerData> layersAtY : balloon.getGraph().getAllLayers()) {
+            for (final BalloonLayerData layer : layersAtY) {
+                for (final long chunkLong : layer.getChunks().keySet()) {
+                    final int chunkX = BalloonLayerData.getChunkX(chunkLong);
+                    final int chunkZ = BalloonLayerData.getChunkZ(chunkLong);
+                    final ObjectList<Balloon> candidates = controllersByLayerChunk.get(getLayerChunkKey(chunkX, layer.getYLevel(), chunkZ));
+
+                    if (candidates == null) {
+                        continue;
+                    }
+
+                    for (final Balloon otherBalloon : candidates) {
+                        if (balloon == otherBalloon) {
+                            continue;
+                        }
+
+                        if (balloon.getBounds().intersects(otherBalloon.getBounds()) &&
+                                balloon.getGraph().getLayerAt(otherBalloon.getControllerPos()) != null) {
+                            return otherBalloon;
+                        }
+                    }
                 }
             }
         }
+
+        return null;
+    }
+
+    private static void removeControllerFromIndex(final Balloon balloon,
+                                                  final Long2ObjectOpenHashMap<ObjectList<Balloon>> controllersByLayerChunk) {
+        final long key = getLayerChunkKey(balloon.getControllerPos());
+        final ObjectList<Balloon> balloons = controllersByLayerChunk.get(key);
+
+        if (balloons == null) {
+            return;
+        }
+
+        balloons.remove(balloon);
+
+        if (balloons.isEmpty()) {
+            controllersByLayerChunk.remove(key);
+        }
+    }
+
+    private static long getLayerChunkKey(final BlockPos pos) {
+        return getLayerChunkKey(pos.getX() >> BalloonLayerData.LAYER_CHUNK_SHIFT, pos.getY(), pos.getZ() >> BalloonLayerData.LAYER_CHUNK_SHIFT);
+    }
+
+    private static long getLayerChunkKey(final int chunkX, final int y, final int chunkZ) {
+        return BlockPos.asLong(chunkX, y, chunkZ);
     }
 
     /**
      * Remove non-valid balloons
      */
-    private void removeBalloons() {
+    private boolean removeBalloons() {
         final ObjectIterator<Balloon> iter = this.balloons.iterator();
+        boolean changed = false;
 
         while (iter.hasNext()) {
             final Balloon balloon = iter.next();
@@ -147,8 +234,11 @@ public class BalloonMap {
             if (!balloon.isValid()) {
                 iter.remove();
                 balloon.onRemoved();
+                changed = true;
             }
         }
+
+        return changed;
     }
 
     /**
@@ -156,7 +246,10 @@ public class BalloonMap {
      * @param balloon the balloon to remove
      */
     public void removeBalloon(final Balloon balloon) {
-        balloon.onRemoved();
+        if (this.balloons.remove(balloon)) {
+            balloon.onRemoved();
+            this.markDirty();
+        }
     }
 
     @Nullable
@@ -235,6 +328,7 @@ public class BalloonMap {
 
                 final BalloonMap map = BalloonMap.MAP.get(this.level);
                 final Iterator<Balloon> iter = map.getBalloons().iterator();
+                boolean changed = false;
 
                 while (iter.hasNext()) {
                     final Balloon balloon = iter.next();
@@ -246,7 +340,12 @@ public class BalloonMap {
                     if (plot.contains(controllerPos.getX(), controllerPos.getZ())) {
                         balloon.onRemoved();
                         iter.remove();
+                        changed = true;
                     }
+                }
+
+                if (changed) {
+                    map.markDirty();
                 }
             }
         }


### PR DESCRIPTION
## Summary

Optimize `BalloonMap` ticking by replacing the global O(n²) balloon merge scan with a controller-position spatial index, and avoid marking balloon save data dirty every tick when no persisted state changed.

## Why

`BalloonMap.tick()` previously performed two expensive operations on every tick:

1. It marked balloon save data dirty unconditionally.
2. It checked every balloon against every other balloon during merge detection.

The merge scan was the serious issue. With `n` active balloons, the previous algorithm performed O(n²) pair checks every tick, even when balloons were far apart and could never merge.

## What Changed

- Added a spatial index keyed by the same `8x8x1` layer chunks used by `BalloonLayerData`.
- Indexed each balloon by its controller position.
- During merge detection, each balloon now scans only the graph chunks it actually owns and only checks controllers found in those chunks.
- Preserved the original precise merge predicate:
  - bounds must intersect
  - the other balloon controller must resolve to a real layer in the current balloon graph
- Changed balloon ticking to report whether persisted state actually changed.
- `BalloonMap` now marks save data dirty only after real changes such as add/remove/merge/unload, controller or bounds changes, gas data changes, or block updates that affect nearby balloons.

## Performance Impact

The merge discovery path changes from global pairwise scanning:

```text
O(n²)
```

to approximately:

```text
O(n + occupied layer chunks + local controller candidates)
```

For many dispersed balloons, this reduces merge candidate checks from all balloon pairs to near-zero local candidates. In the worst case where many controllers occupy the same layer chunk, local candidate checks can still be high, but the cost is now tied to local density instead of total world balloon count.

No runtime benchmark was added, so this PR does not claim a measured percentage improvement. The improvement is algorithmic: global quadratic work is removed from the normal dispersed case.

## Safety

This should be behavior-preserving for merge correctness because the spatial index is only a prefilter.

A balloon can only merge with another balloon if the other balloon's controller position is inside its graph. If that condition is true, the controller position must also be inside one of the graph's `8x8x1` layer chunks, so the new index will still find it. The original exact checks remain in place before merging.

Checked edge cases:

- balloons separated on the same Y layer
- balloons separated inside the same layer chunk
- controller position inside another balloon graph
- many dispersed balloons
- block changes that mutate balloon graph data after removing unconditional dirty marking