### PR TITLE
Fix rope holder state after movement

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeHolderBlock.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeHolderBlock.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public interface RopeHolderBlock <T extends SmartBlockEntity> extends BlockSubLevelAssemblyListener, IBE<T> {
@@ -53,31 +54,37 @@ public interface RopeHolderBlock <T extends SmartBlockEntity> extends BlockSubLe
 
     @Override
     default void afterMove(final ServerLevel originLevel, final ServerLevel serverLevel, final BlockState blockState, final BlockPos oldPos, final BlockPos newPos) {
-        final AtomicReference<ServerRopeStrand> ownedStrand = new AtomicReference<>();
+        final AtomicBoolean wasStrandOwner = new AtomicBoolean(false);
+        final AtomicReference<ServerRopeStrand> movedStrand = new AtomicReference<>();
         this.withBlockEntityDo(originLevel, oldPos, be -> {
             final RopeStrandHolderBehavior holder = this.getHolder(be);
-            ownedStrand.set(holder.getOwnedStrand());
+            wasStrandOwner.set(holder.ownsRope());
+            ServerRopeStrand strand = holder.getAttachedStrand();
+            if (strand == null) {
+                strand = holder.getOwnedStrand();
+            }
+            movedStrand.set(strand);
             holder.detachRope();
         });
         this.withBlockEntityDo(serverLevel, newPos, be -> {
             final RopeStrandHolderBehavior holder = this.getHolder(be);
+            final ServerRopeStrand strand = movedStrand.get();
 
-            if (ownedStrand.get() != null && holder.ownsRope()) {
-                holder.takeOwnedStrand(ownedStrand.get());
+            if (strand == null) {
+                return;
             }
 
-            final ServerRopeStrand strand = holder.getAttachedStrand();
+            final boolean ownsStrand = wasStrandOwner.get();
+            holder.takeMovedStrand(strand, ownsStrand);
 
-            if (strand != null) {
-                strand.getTrackingPlayers().clear();
-                final SubLevel newSubLevel = Sable.HELPER.getContaining(serverLevel, newPos);
-                final UUID newSubLevelId = newSubLevel != null ? newSubLevel.getUniqueId() : null;
+            strand.getTrackingPlayers().clear();
+            final SubLevel newSubLevel = Sable.HELPER.getContaining(serverLevel, newPos);
+            final UUID newSubLevelId = newSubLevel != null ? newSubLevel.getUniqueId() : null;
 
-                final RopeAttachmentPoint point = holder.ownsRope() ? RopeAttachmentPoint.START : RopeAttachmentPoint.END;
-                final RopeAttachment attachment = new RopeAttachment(point, newSubLevelId, newPos);
+            final RopeAttachmentPoint point = ownsStrand ? RopeAttachmentPoint.START : RopeAttachmentPoint.END;
+            final RopeAttachment attachment = new RopeAttachment(point, newSubLevelId, newPos);
 
-                strand.addAttachment(serverLevel, point, attachment);
-            }
+            strand.addAttachment(serverLevel, point, attachment);
         });
     }
 

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
@@ -158,20 +158,25 @@ public class RopeStrandHolderBehavior extends BlockEntityBehaviour {
 
     @NotNull
     public ClientboundRopeDataPacket makeUpdatePacket() {
+        return this.makeUpdatePacket(Objects.requireNonNull(this.ownedServerStrand));
+    }
+
+    @NotNull
+    public ClientboundRopeDataPacket makeUpdatePacket(final ServerRopeStrand strand) {
         final ServerSubLevelContainer container = (ServerSubLevelContainer) SubLevelContainer.getContainer(this.getLevel());
         assert container != null;
 
         final SubLevelTrackingSystem trackingSystem = container.trackingSystem();
 
         //todo can be null from schematics
-        final RopeAttachment startAttachment = this.ownedServerStrand.getAttachment(RopeAttachmentPoint.START);
-        final RopeAttachment endAttachment = this.ownedServerStrand.getAttachment(RopeAttachmentPoint.END);
+        final RopeAttachment startAttachment = strand.getAttachment(RopeAttachmentPoint.START);
+        final RopeAttachment endAttachment = strand.getAttachment(RopeAttachmentPoint.END);
 
         return new ClientboundRopeDataPacket(
                 trackingSystem.getInterpolationTick(),
                 this.blockEntity.getBlockPos(),
-                this.ownedServerStrand.getUUID(),
-                new ObjectArrayList<>(this.ownedServerStrand.getPoints()),
+                strand.getUUID(),
+                new ObjectArrayList<>(strand.getPoints()),
                 startAttachment != null ? startAttachment.blockAttachment() : null,
                 endAttachment != null ? endAttachment.blockAttachment() : null
         );
@@ -624,7 +629,14 @@ public class RopeStrandHolderBehavior extends BlockEntityBehaviour {
     }
 
     public void takeOwnedStrand(final ServerRopeStrand ownedStrand) {
-        this.ownedServerStrand = ownedStrand;
+        this.takeMovedStrand(ownedStrand, true);
+    }
+
+    public void takeMovedStrand(final ServerRopeStrand strand, final boolean ownsStrand) {
+        this.strandOwner = ownsStrand;
+        this.attachedRopeID = strand.getUUID();
+        this.ownedServerStrand = ownsStrand ? strand : null;
+        this.blockEntity.setChanged();
     }
 
     public void receiveClientStrandStopped() {

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/strand/server/ServerRopeTrackingSystem.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/strand/server/ServerRopeTrackingSystem.java
@@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -40,9 +41,7 @@ public class ServerRopeTrackingSystem implements SubLevelTrackingPlugin {
                 continue;
             }
 
-            final RopeAttachment attachment = strand.getAttachment(RopeAttachmentPoint.START);
-            final BlockPos block = attachment.blockAttachment();
-            final RopeStrandHolderBehavior holder = RopeStrandHolderBehavior.get(this.level.getBlockEntity(block), RopeStrandHolderBehavior.TYPE);
+            final RopeStrandHolderBehavior holder = this.getStartHolder(strand);
 
             if (holder == null) {
                 continue;
@@ -67,22 +66,18 @@ public class ServerRopeTrackingSystem implements SubLevelTrackingPlugin {
             if (strand.needsSync()) {
                 strand.networkingStopped = false;
 
-                final RopeAttachment attachment = strand.getAttachment(RopeAttachmentPoint.START);
-                final BlockPos block = attachment.blockAttachment();
-                final RopeStrandHolderBehavior holder = RopeStrandHolderBehavior.get(this.level.getBlockEntity(block), RopeStrandHolderBehavior.TYPE);
+                final RopeStrandHolderBehavior holder = this.getStartHolder(strand);
 
                 if (holder == null) {
                     continue;
                 }
 
-                holder.getStrandPacketSink().sendPacket(holder.makeUpdatePacket());
+                holder.getStrandPacketSink().sendPacket(holder.makeUpdatePacket(strand));
                 strand.justSynced();
             } else if (!strand.networkingStopped) {
                 strand.networkingStopped = true;
 
-                final RopeAttachment attachment = strand.getAttachment(RopeAttachmentPoint.START);
-                final BlockPos block = attachment.blockAttachment();
-                final RopeStrandHolderBehavior holder = RopeStrandHolderBehavior.get(this.level.getBlockEntity(block), RopeStrandHolderBehavior.TYPE);
+                final RopeStrandHolderBehavior holder = this.getStartHolder(strand);
 
                 if (holder == null) {
                     continue;
@@ -91,5 +86,35 @@ public class ServerRopeTrackingSystem implements SubLevelTrackingPlugin {
                 holder.getStrandPacketSink().sendPacket(holder.makeStopPacket());
             }
         }
+    }
+
+    @Nullable
+    private RopeStrandHolderBehavior getStartHolder(final ServerRopeStrand strand) {
+        final RopeAttachment attachment = strand.getAttachment(RopeAttachmentPoint.START);
+
+        if (attachment == null) {
+            return null;
+        }
+
+        final BlockPos block = attachment.blockAttachment();
+        final RopeStrandHolderBehavior holder = RopeStrandHolderBehavior.get(this.level.getBlockEntity(block), RopeStrandHolderBehavior.TYPE);
+
+        if (holder == null) {
+            return null;
+        }
+
+        final ServerRopeStrand ownedStrand = holder.getOwnedStrand();
+        if (ownedStrand != null) {
+            return ownedStrand.getUUID().equals(strand.getUUID()) ? holder : null;
+        }
+
+        final ServerRopeStrand attachedStrand = holder.getAttachedStrand();
+        if (attachedStrand != null && !attachedStrand.getUUID().equals(strand.getUUID())) {
+            return null;
+        }
+
+        holder.takeOwnedStrand(strand);
+
+        return holder;
     }
 }


### PR DESCRIPTION
## Summary
- Preserve rope strand ownership and attachment identity when rope holder blocks move.
- Send rope tracking updates from the active server strand instead of assuming the start holder still has an owned strand.
- Repair stale start-holder state during tracking when an old world has a strand in the manager but no owned strand on the holder.

## Root Cause
Moving a rope holder could detach the old block entity before the new block entity restored the same rope ownership state. That left the server rope manager with an active strand while the START holder had a null ownedServerStrand. On world tick, rope tracking asked the holder to build an update packet and crashed with a NullPointerException.

## Impact
Worlds containing this stale rope state should no longer crash on load, and moving rope-connected blocks should preserve the rope endpoint identity correctly.

Fixes #1168