### PR TITLE
Fix docking connector fluid reconnection after reloads

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorBlockEntity.java
@@ -1,5 +1,9 @@
 package dev.simulated_team.simulated.content.blocks.docking_connector;
 
+import com.simibubi.create.content.fluids.FluidPropagator;
+import com.simibubi.create.content.fluids.FluidTransportBehaviour;
+import com.simibubi.create.content.fluids.PipeConnection;
+import com.simibubi.create.content.fluids.pump.PumpBlockEntity;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import dev.ryanhcode.sable.Sable;
@@ -17,6 +21,8 @@ import dev.simulated_team.simulated.compat.computercraft.wired.DockingConnectorW
 import dev.simulated_team.simulated.content.blocks.redstone_magnet.*;
 import dev.simulated_team.simulated.index.SimBlocks;
 import dev.simulated_team.simulated.index.SimSoundEvents;
+import dev.simulated_team.simulated.mixin.accessor.PipeConnectionAccessor;
+import dev.simulated_team.simulated.service.SimPlatformService;
 import dev.simulated_team.simulated.multiloader.inventory.AbstractContainer;
 import dev.simulated_team.simulated.service.SimConfigService;
 import dev.simulated_team.simulated.util.SimMathUtils;
@@ -34,6 +40,7 @@ import net.minecraft.world.Clearable;
 import net.minecraft.world.entity.monster.Shulker;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ShulkerBoxBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -47,9 +54,12 @@ import java.lang.Math;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 public class DockingConnectorBlockEntity extends SmartBlockEntity implements SimMagnet, BlockEntitySubLevelActor, Clearable {
+    private static final int PIPE_NETWORK_REFRESH_DELAY = 2;
+
     public static MagnetMap<DockingConnectorBlockEntity> MAGNET_CONTROLLER = new MagnetMap<>();
     public boolean powered;
     public LerpedFloat extension = LerpedFloat.linear().chase(0, 0.1, LerpedFloat.Chaser.LINEAR);
@@ -67,6 +77,7 @@ public class DockingConnectorBlockEntity extends SmartBlockEntity implements Sim
     public final DockingConnectorWiredElement ccWiredElement;
 
     private ConstraintSmoother constraintSmoother = null;
+    private int pipeNetworkRefreshDelay = 0;
 
     public DockingConnectorBlockEntity(final BlockEntityType<?> type, final BlockPos pos, final BlockState state) {
         super(type, pos, state);
@@ -101,22 +112,22 @@ public class DockingConnectorBlockEntity extends SmartBlockEntity implements Sim
         final DockingConnectorBlockEntity otherConnector = this.getOtherConnector();
 
         if (otherConnector != null && this.constraintHandle == null && otherConnector.constraintHandle == null) {
-            final MagnetMap<DockingConnectorBlockEntity> controller = DockingConnectorBlockEntity.MAGNET_CONTROLLER;
-            if (controller.getPair(this.level, this.getBlockPos(), this.otherConnectorPosition) == null) {
-                controller.tryAddPair(this.level, this.getBlockPos(), this.otherConnectorPosition, DockingConnectorPair::new);
-                final DockingConnectorPair pair = (DockingConnectorPair) controller.getPair(this.level, this.getBlockPos(), this.otherConnectorPosition);
-
-                if (pair != null) {
-                    pair.dock(true);
-                    this.notifyUpdate();
-                }
-            }
+            this.restoreDockingPair(otherConnector);
+            this.notifyUpdate();
         }
     }
 
     @Override
     public void tick() {
         super.tick();
+
+        if (this.pipeNetworkRefreshDelay > 0) {
+            this.pipeNetworkRefreshDelay--;
+            if (this.pipeNetworkRefreshDelay == 0) {
+                this.refreshPipeNetwork();
+            }
+        }
+
         final BlockState state = this.getBlockState();
         final Direction direction = state.getValue(BlockStateProperties.FACING);
         final BlockPos pos = this.getBlockPos();
@@ -136,8 +147,12 @@ public class DockingConnectorBlockEntity extends SmartBlockEntity implements Sim
             }
         }
 
-        if (this.otherConnectorPosition != null && !this.level.isClientSide) {
-            if (!(this.level.getBlockEntity(this.otherConnectorPosition) instanceof final DockingConnectorBlockEntity be && Objects.equals(be.otherConnectorPosition, this.getBlockPos()))) {
+        if (this.otherConnectorPosition != null && !this.level.isClientSide && this.level.isLoaded(this.otherConnectorPosition)) {
+            if (this.level.getBlockEntity(this.otherConnectorPosition) instanceof final DockingConnectorBlockEntity be && Objects.equals(be.otherConnectorPosition, this.getBlockPos())) {
+                if (!this.tank.isConnectedTo(be.tank)) {
+                    this.restoreDockingPair(be);
+                }
+            } else {
                 this.unDock();
                 this.state = DockingConnectorState.EXTENDED;
                 this.sendData();
@@ -282,6 +297,15 @@ public class DockingConnectorBlockEntity extends SmartBlockEntity implements Sim
         }
     }
 
+    private void restoreDockingPair(final DockingConnectorBlockEntity otherConnector) {
+        final MagnetMap<DockingConnectorBlockEntity> controller = DockingConnectorBlockEntity.MAGNET_CONTROLLER;
+        controller.tryAddPair(this.level, this.getBlockPos(), otherConnector.getBlockPos(), DockingConnectorPair::new);
+        final DockingConnectorPair pair = (DockingConnectorPair) controller.getPair(this.level, this.getBlockPos(), otherConnector.getBlockPos());
+        if (pair != null) {
+            pair.dock(true);
+        }
+    }
+
     private void updateState() {
 
         if (this.powered) {
@@ -361,6 +385,40 @@ public class DockingConnectorBlockEntity extends SmartBlockEntity implements Sim
             rotation *= rotation;
         }
         return rotation;
+    }
+
+    void onFluidConnectionChanged() {
+        if (this.level != null && !this.level.isClientSide()) {
+            SimPlatformService.INSTANCE.invalidateCapabilities(this);
+            this.pipeNetworkRefreshDelay = PIPE_NETWORK_REFRESH_DELAY;
+        }
+    }
+
+    private void refreshPipeNetwork() {
+        if (this.level == null || this.level.isClientSide()) {
+            return;
+        }
+
+        for (final Direction direction : Direction.values()) {
+            final BlockPos neighborPos = this.worldPosition.relative(direction);
+            final FluidTransportBehaviour pipe = FluidPropagator.getPipe(this.level, neighborPos);
+            if (pipe == null) {
+                continue;
+            }
+            final PipeConnection endpoint = pipe.getConnection(direction.getOpposite());
+            if (endpoint != null) {
+                final PipeConnectionAccessor endpointAccessor = (PipeConnectionAccessor) endpoint;
+                endpointAccessor.simulated$setSource(Optional.empty());
+                endpointAccessor.simulated$setFlow(Optional.empty());
+            }
+
+            final BlockEntity neighbor = this.level.getBlockEntity(neighborPos);
+            if (neighbor instanceof final PumpBlockEntity pump && pump.isSideAccessible(direction.getOpposite())) {
+                pump.updatePressureChange();
+            } else {
+                FluidPropagator.propagateChangedPipe(this.level, neighborPos, this.level.getBlockState(neighborPos));
+            }
+        }
     }
 
     public void setDock(final DockingConnectorBlockEntity otherConnector, final boolean isLocked, @Nullable final Quaterniondc targetOrientation, final Vector3dc relativePos, final Quaterniondc relativeOrientation) {

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorTank.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/docking_connector/DockingConnectorTank.java
@@ -20,13 +20,21 @@ public class DockingConnectorTank extends SingleTank {
     }
 
     public void connect(final BlockPos pos, final DockingConnectorTank other) {
+        if (pos.equals(this.connectedPos) && this.connectedTank == other) {
+            return;
+        }
         this.connectedPos = pos;
         this.connectedTank = other;
+        this.blockEntity.onFluidConnectionChanged();
     }
 
     public void disconnect() {
+        if (this.connectedPos == null && this.connectedTank == null) {
+            return;
+        }
         this.connectedPos = null;
         this.connectedTank = null;
+        this.blockEntity.onFluidConnectionChanged();
     }
 
     private boolean canInteract() {
@@ -40,6 +48,10 @@ public class DockingConnectorTank extends SingleTank {
         }
 
         return this.connectedTank == other.tank;
+    }
+
+    boolean isConnectedTo(final DockingConnectorTank other) {
+        return this.connectedTank == other && this.canInteract();
     }
 
     @Override

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/accessor/PipeConnectionAccessor.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/accessor/PipeConnectionAccessor.java
@@ -1,0 +1,18 @@
+package dev.simulated_team.simulated.mixin.accessor;
+
+import com.simibubi.create.content.fluids.FlowSource;
+import com.simibubi.create.content.fluids.PipeConnection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Optional;
+
+@Mixin(PipeConnection.class)
+public interface PipeConnectionAccessor {
+
+    @Accessor("source")
+    void simulated$setSource(Optional<FlowSource> source);
+
+    @Accessor("flow")
+    void simulated$setFlow(Optional<PipeConnection.Flow> flow);
+}

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/multiloader/tanks/CFluidType.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/multiloader/tanks/CFluidType.java
@@ -5,6 +5,7 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import dev.simulated_team.simulated.Simulated;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.TypedDataComponent;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
@@ -13,6 +14,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * A loader-independent representation of a fluid
@@ -24,12 +27,17 @@ public class CFluidType {
 
     public CFluidType(final ResourceLocation type, @Nullable final DataComponentMap data) {
         this.fluid = BuiltInRegistries.FLUID.get(type);
-        this.data = data;
+        this.data = normalize(data);
     }
 
     public CFluidType(final Fluid type, @Nullable final DataComponentMap data) {
         this.fluid = type;
-        this.data = data;
+        this.data = normalize(data);
+    }
+
+    @Nullable
+    private static DataComponentMap normalize(@Nullable final DataComponentMap data) {
+        return data == null || data.isEmpty() ? null : data;
     }
 
     public boolean isBlank() {
@@ -75,11 +83,38 @@ public class CFluidType {
         }
 
         if (obj instanceof final CFluidType other) {
-            // both haves tag, or both no haves tag
-            if ((this.data == null) == (other.data == null)) {
-                return this.fluid.isSame(other.fluid) && (this.data == null || this.data.equals(other.data));
-            }
+            return this.fluid.isSame(other.fluid) && componentsMatch(this.data, other.data);
         }
         return false;
+    }
+
+    private static boolean componentsMatch(@Nullable final DataComponentMap first, @Nullable final DataComponentMap second) {
+        if (first == second) {
+            return true;
+        }
+        if (first == null || second == null || first.size() != second.size()) {
+            return false;
+        }
+        for (final TypedDataComponent<?> component : first) {
+            if (!componentMatches(component, second)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static <T> boolean componentMatches(final TypedDataComponent<T> component, final DataComponentMap other) {
+        return Objects.equals(component.value(), other.get(component.type()));
+    }
+
+    @Override
+    public int hashCode() {
+        int componentHash = 0;
+        if (this.data != null) {
+            for (final TypedDataComponent<?> component : this.data) {
+                componentHash += Objects.hash(component.type(), component.value());
+            }
+        }
+        return 31 * this.fluid.hashCode() + componentHash;
     }
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/service/SimPlatformService.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/service/SimPlatformService.java
@@ -1,8 +1,12 @@
 package dev.simulated_team.simulated.service;
 
+import net.minecraft.world.level.block.entity.BlockEntity;
+
 public interface SimPlatformService {
 
 	SimPlatformService INSTANCE = ServiceUtil.load(SimPlatformService.class);
 
 	boolean isLoaded(String modId);
+
+	void invalidateCapabilities(BlockEntity blockEntity);
 }

--- a/simulated/common/src/main/resources/simulated.mixins.json
+++ b/simulated/common/src/main/resources/simulated.mixins.json
@@ -54,6 +54,7 @@
     "accessor.ControlledContraptionEntityAccessor",
     "accessor.CreateBlockEntityBuilderAccessor",
     "accessor.ParrotElementAccessor",
+    "accessor.PipeConnectionAccessor",
     "accessor.RedstoneLinkBlockEntityAccessor",
     "accessor.WorldSectionElementAccessor",
     "assembly_preventer.ServerSubLevelMixin",

--- a/simulated/neoforge/src/main/java/dev/simulated_team/simulated/neoforge/service/NeoForgeSimPlatformService.java
+++ b/simulated/neoforge/src/main/java/dev/simulated_team/simulated/neoforge/service/NeoForgeSimPlatformService.java
@@ -1,6 +1,7 @@
 package dev.simulated_team.simulated.neoforge.service;
 
 import dev.simulated_team.simulated.service.SimPlatformService;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.fml.ModList;
 
 public class NeoForgeSimPlatformService implements SimPlatformService {
@@ -8,5 +9,12 @@ public class NeoForgeSimPlatformService implements SimPlatformService {
 	@Override
 	public boolean isLoaded(final String modId) {
 		return ModList.get().isLoaded(modId);
+	}
+
+	@Override
+	public void invalidateCapabilities(final BlockEntity blockEntity) {
+		if (blockEntity.getLevel() != null && !blockEntity.getLevel().isClientSide()) {
+			blockEntity.getLevel().invalidateCapabilities(blockEntity.getBlockPos());
+		}
 	}
 }


### PR DESCRIPTION
Closes #1209.

## Summary

- invalidate the docking connector's fluid capability when its runtime tank connection changes
- clear Create's cached pipe endpoint source and flow before propagating the network update
- compare serialized fluid components structurally instead of relying on implementation-specific `DataComponentMap.equals`
- preserve saved docking relations while the counterpart chunk is unloaded and restore the runtime pair once both connectors are available

## Root cause

The failure had three interacting causes:

1. Create retained `PipeConnection.source` and `PipeConnection.flow` after the connector's capability changed, so a normal neighbor update did not fully rebuild the endpoint.
2. A fluid loaded from NBT used a plain `DataComponentMap`, while a live `FluidStack` used `PatchedDataComponentMap`. Their implementation-specific equality check rejected otherwise identical fluids until the connector's local buffer emptied.
3. During asynchronous chunk or sublevel loading, one connector could tick before its counterpart block entity existed. This temporary absence was treated as a real disconnect and cleared the persisted pair.

## Rebased onto v1.3.0

This PR has been rebased onto the latest `main` (v1.3.0, commit `0da5d07` and later). The fix remains valid and necessary — none of the three root causes have been addressed by upstream:

| Upstream v1.3.0 change | Relation to this fix |
|---|---|
| `0da5d07` Docking connector blockstate update (fix #775) | **Independent.** Fixes visual extension sync using `extension.getValue() == 1.0` precision check and `flags=6` block update. Does not touch fluid logic. Our fix sits cleanly on top. |
| Sable API rename (`constraint.fixed` → `constraint`) | **Included.** The rebased branch uses the updated import paths. |
| `646a468` Typewriter name networking refactor | **Unrelated.** No overlap with docking connector code. |

**What upstream did NOT fix:**
- ❌ Stale `PipeConnection.source`/`flow` after tank target changes — still present
- ❌ `CFluidType.equals()` mismatch between `PatchedDataComponentMap` and plain `DataComponentMap` — still present
- ❌ Chunk/sublevel load ordering causing premature pair invalidation — still present

## Changes (7 files, +154/-18)

| File | Change |
|---|---|
| `DockingConnectorBlockEntity.java` | `refreshPipeNetwork()`: clears adjacent `PipeConnection.source`/`flow` via accessor, then calls `FluidPropagator.propagateChangedPipe()` or `PumpBlockEntity.updatePressureChange()`. `onFluidConnectionChanged()`: invalidates capabilities + schedules delayed refresh. |
| `DockingConnectorTank.java` | `isConnectedTo()` + connect/disconnect dedup + triggers `onFluidConnectionChanged`. |
| `PipeConnectionAccessor.java` | **New Mixin.** Accessor for `PipeConnection.source` and `PipeConnection.flow`. |
| `CFluidType.java` | Structural `equals()` comparing component-by-component (handles `PatchedDataComponentMap` vs plain `DataComponentMap`), matching `hashCode()`. |
| `SimPlatformService.java` | New `invalidateCapabilities(BlockEntity)` method. |
| `NeoForgeSimPlatformService.java` | Implements `invalidateCapabilities` via `level.invalidateCapabilities(pos)`. |
| `simulated.mixins.json` | Registers `PipeConnectionAccessor`. |

## Validation

- `./gradlew clean build --console=plain`
- disconnecting stops fluid transfer and reconnecting resumes it
- reconnecting continues to work after a server restart while the connectors were docked
- reconnecting continues to work after unloading the area by travelling away and returning
- tested in the Aeronautics 1.21.1 NeoForge modpack with Create Fluid Logistics pumps
- **re-tested on v1.3.0 bundled jar in a full modpack** — all scenarios pass