### PR TITLE
Fix: prevent client-side rope strand tick crash

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
@@ -307,7 +307,7 @@ public class RopeStrandHolderBehavior extends BlockEntityBehaviour {
     public void unload() {
         final Level level = this.getLevel();
 
-        if (this.ownedServerStrand != null) {
+        if (!level.isClientSide() && this.ownedServerStrand != null) {
             this.removeServerStrand(level);
         }
 

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/rope/RopeStrandHolderBehavior.java
@@ -78,7 +78,7 @@ public class RopeStrandHolderBehavior extends BlockEntityBehaviour {
     public void tick() {
         super.tick();
 
-        if (this.ownedServerStrand != null) {
+        if (!this.getLevel().isClientSide() && this.ownedServerStrand != null) {
             if (this.queuedLevelAddition) {
                 this.addServerStrand(this.ownedServerStrand);
                 this.queuedLevelAddition = false;
@@ -328,7 +328,11 @@ public class RopeStrandHolderBehavior extends BlockEntityBehaviour {
 
     private void addServerStrand(final ServerRopeStrand strand) {
         this.ownedServerStrand = strand;
-        ServerLevelRopeManager.getOrCreate(this.getLevel())
+        final Level level = this.getLevel();
+        if (level.isClientSide()) {
+            return;
+        }
+        ServerLevelRopeManager.getOrCreate(level)
                 .addStrand(this.ownedServerStrand);
     }
 


### PR DESCRIPTION
Fixes #1253

**Problem**

`RopeStrandHolderBehavior.tick()` runs on both client and server, but the server-strand logic (`ServerLevelRopeManager`, `SubLevelPhysicsSystem`, `ServerLevel` casts) must never execute on the client. When a chunk with a rope winch loads on the client, the block entity NBT deserializes `ownedServerStrand` and sets `queuedLevelAddition = true`, causing the next client tick to crash with either NPE or ClassCastException.

**Fix**

Two changes in `RopeStrandHolderBehavior.java`:

1. **`tick()`** — Guard the server-strand block with `!isClientSide()`:
   ```java
   if (!this.getLevel().isClientSide() && this.ownedServerStrand != null) {
   ```
   The client-side `ownedClientStrand` block at the end of `tick()` continues to run normally.

2. **`addServerStrand()`** — Defensive `isClientSide()` guard before `ServerLevelRopeManager.getOrCreate()`:
   ```java
   if (level.isClientSide()) {
       return;
   }
   ```

**Testing**

Verified on Sable 2.0.1 + Simulated 1.3.0 multiplayer server. Previously, loading a chunk with a rope winch crashed the client. After the fix, the chunk loads and ropes render correctly.