### PR TITLE
Fix hard-edge rendering ghost caused by veil effects when Iris on

### DIFF
--- a/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/effect/ClientBalloonEffectRenderer.java
+++ b/aeronautics/common/src/main/java/dev/eriksonn/aeronautics/content/blocks/hot_air/balloon/effect/ClientBalloonEffectRenderer.java
@@ -13,7 +13,9 @@ import foundry.veil.api.client.render.post.PostPipeline;
 import foundry.veil.api.client.render.post.PostProcessingManager;
 import foundry.veil.api.client.render.shader.program.ShaderProgram;
 import foundry.veil.api.client.render.shader.uniform.ShaderUniformAccess;
+import foundry.veil.api.compat.IrisCompat;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
+import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.resources.ResourceLocation;
@@ -42,6 +44,9 @@ public class ClientBalloonEffectRenderer {
                                           final Matrix4fc projectionMatrix,
                                           final int renderTick) {
         if (stage != VeilRenderLevelStageEvent.Stage.AFTER_SOLID_BLOCKS) {
+            return;
+        }
+        if (IrisCompat.isLoaded() && IrisApi.getInstance().isRenderingShadowPass()) {
             return;
         }
 

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/end_sea/EndSeaShadowRenderer.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/end_sea/EndSeaShadowRenderer.java
@@ -16,8 +16,10 @@ import foundry.veil.api.client.render.VeilRenderSystem;
 import foundry.veil.api.client.render.framebuffer.AdvancedFbo;
 import foundry.veil.api.client.render.post.PostPipeline;
 import foundry.veil.api.client.render.post.PostProcessingManager;
+import foundry.veil.api.compat.IrisCompat;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
@@ -49,6 +51,9 @@ public class EndSeaShadowRenderer {
     public static void renderShadowMap(final VeilRenderLevelStageEvent.Stage stage, final LevelRenderer levelRenderer, final MultiBufferSource.BufferSource bufferSource, final MatrixStack matrixStack, final Matrix4fc frustumMatrix, final Matrix4fc projectionMatrix, final int renderTick, final DeltaTracker deltaTracker, final Camera camera, final Frustum frustum) {
         if (!EndSeaShadowRenderer.isEnabled() ||
                 stage != VeilRenderLevelStageEvent.Stage.AFTER_LEVEL) {
+            return;
+        }
+        if (IrisCompat.isLoaded() && IrisApi.getInstance().isRenderingShadowPass()) {
             return;
         }
 

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/physics_staff/PhysicsStaffRenderHandler.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/physics_staff/PhysicsStaffRenderHandler.java
@@ -14,8 +14,10 @@ import dev.simulated_team.simulated.index.SimItems;
 import dev.simulated_team.simulated.index.SimRenderTypes;
 import foundry.veil.api.client.color.Color;
 import foundry.veil.api.client.render.MatrixStack;
+import foundry.veil.api.compat.IrisCompat;
 import foundry.veil.api.event.VeilRenderLevelStageEvent;
 import net.createmod.catnip.outliner.Outliner;
+import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
@@ -48,6 +50,9 @@ public class PhysicsStaffRenderHandler {
      */
     public static void renderSelectionBox(final VeilRenderLevelStageEvent.Stage stage, final LevelRenderer renderer, final MultiBufferSource.BufferSource bufferSource, final MatrixStack ps, final Matrix4fc frustrumMat, final Matrix4fc projectionMat, final int renderTick, final DeltaTracker tracker, final Camera camera, final Frustum frustrum) {
         if (stage != VeilRenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) return;
+        if (IrisCompat.isLoaded() && IrisApi.getInstance().isRenderingShadowPass()) {
+            return;
+        }
 
         if (Minecraft.getInstance().options.hideGui) {
             return;


### PR DESCRIPTION
Fix hard edge rendering ghost cause by veil effects rendering during Iris shadow pass
By:
Prevents Veil render-stage effects from running during Iris shadow passes.

Before:
<img width="1008" height="751" alt="image" src="https://github.com/user-attachments/assets/034d5642-9ac8-4774-8268-ed0bcc341875" />

After:
<img width="1016" height="766" alt="image" src="https://github.com/user-attachments/assets/ecacb2e8-b817-4d48-a5a6-bd3084c8eb79" />

This fixes hard-edge ghost artifacts caused by the hot air overlay and guards similar End Sea / physics staff render paths.