### PR TITLE
[Offroad] Allow tires to specify a minimum friction value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff
 .idea/
+.vscode/
 
 *.iml
 *.ipr

--- a/offroad/common/src/main/java/dev/ryanhcode/offroad/content/blocks/wheel_mount/WheelMountBlockEntity.java
+++ b/offroad/common/src/main/java/dev/ryanhcode/offroad/content/blocks/wheel_mount/WheelMountBlockEntity.java
@@ -63,7 +63,7 @@ import org.joml.Vector3dc;
 import java.util.Collection;
 import java.util.List;
 
-public class WheelMountBlockEntity extends KineticBlockEntity implements BlockEntitySubLevelActor, Clearable, ClipboardCloneable, SpecialBlockEntityItemRequirement {
+public class WheelMountBlockEntity extends KineticBlockEntity implements BlockEntitySubLevelActor, Clearable, ClipboardCloneable {
     private static final MutableComponent SCROLL_OPTION_TITLE = OffroadLang.translate("scroll_option.suspension_strength").component();
     private static final double MAX_ALLOWED_EXTENSION = 0.65;
     private static final double NO_WHEEL_EXTENSION = 0.5;
@@ -204,6 +204,8 @@ public class WheelMountBlockEntity extends KineticBlockEntity implements BlockEn
             } else {
                 this.touchingFriction = 1.0;
             }
+
+            this.touchingFriction = Math.max(this.touchingFriction, tire.minimumFriction());
 
             final double brakeStrength = this.level.getSignal(blockPos.above(), Direction.UP) / 15.0;
             final double surfaceBraking = Math.min(this.touchingFriction, 1.0);

--- a/offroad/common/src/main/java/dev/ryanhcode/offroad/content/components/TireLike.java
+++ b/offroad/common/src/main/java/dev/ryanhcode/offroad/content/components/TireLike.java
@@ -25,6 +25,10 @@ public record TireLike(float radius, Vec3 rotation, Vec3 offset, Optional<Resour
         this(radius, rotation, offset, Optional.ofNullable(model), minimumFriction);
     }
 
+    public TireLike(float radius, Vec3 rotation, Vec3 offset, @Nullable ResourceLocation model) {
+        this(radius, rotation, offset, Optional.ofNullable(model), 0.0f);
+    }
+
     public TireLike(final float radius) {
         this(radius, new Vec3(90, 0, 0), new Vec3(0, 0, 0), Optional.empty(), 0.0f);
     }

--- a/offroad/common/src/main/java/dev/ryanhcode/offroad/content/components/TireLike.java
+++ b/offroad/common/src/main/java/dev/ryanhcode/offroad/content/components/TireLike.java
@@ -9,26 +9,28 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.function.Function;
 
-public record TireLike(float radius, Vec3 rotation, Vec3 offset, Optional<ResourceLocation> model) {
+public record TireLike(float radius, Vec3 rotation, Vec3 offset, Optional<ResourceLocation> model, float minimumFriction) {
     public static final Codec<TireLike> CODEC = RecordCodecBuilder.create(
             i -> i.group(
                     Codec.FLOAT.optionalFieldOf("radius", 1.0f).forGetter(TireLike::radius),
                     Vec3.CODEC.optionalFieldOf("rotation", new Vec3(90, 0, 0)).forGetter(TireLike::rotation),
                     Vec3.CODEC.optionalFieldOf("offset", new Vec3(0, 0, 0)).forGetter(TireLike::offset),
-                    ResourceLocation.CODEC.optionalFieldOf("model").forGetter(TireLike::model)
+                    ResourceLocation.CODEC.optionalFieldOf("model").forGetter(TireLike::model),
+                    Codec.FLOAT.optionalFieldOf("minimumFriction", 0.0f).forGetter(TireLike::minimumFriction)
             ).apply(i, TireLike::new));
 
-    public TireLike(float radius, Vec3 rotation, Vec3 offset, @Nullable ResourceLocation model) {
-        this(radius, rotation, offset, Optional.ofNullable(model));
+    public TireLike(float radius, Vec3 rotation, Vec3 offset, @Nullable ResourceLocation model, float minimumFriction) {
+        this(radius, rotation, offset, Optional.ofNullable(model), minimumFriction);
     }
 
     public TireLike(final float radius) {
-        this(radius, new Vec3(90, 0, 0), new Vec3(0, 0, 0), Optional.empty());
+        this(radius, new Vec3(90, 0, 0), new Vec3(0, 0, 0), Optional.empty(), 0.0f);
     }
 
     public TireLike(final float radius, final ResourceLocation model) {
-        this(radius, new Vec3(90, 0, 0), new Vec3(0, 0, 0), Optional.of(model));
+        this(radius, new Vec3(90, 0, 0), new Vec3(0, 0, 0), Optional.of(model), 0.0f);
     }
 
     /*
@@ -45,6 +47,6 @@ public record TireLike(float radius, Vec3 rotation, Vec3 offset, Optional<Resour
     public static final TireLike WATER_WHEEL = new TireLike(1.0f);
     public static final TireLike FLYWHEEL = new TireLike(1.0f + 6.0f / 16.0f);
     public static final TireLike LARGE_WATER_WHEEL = new TireLike(2.0f + 7.0f / 16.0f);
-    public static final TireLike ROCKCUTTING_WHEEL = new TireLike(0.8f, new Vec3(90, 0, 0), Vec3.ZERO, Offroad.path("block/rockcutting_wheel/wheel"));
-    public static final TireLike MECHANICAL_ROLLER = new TireLike(0.7f, Vec3.ZERO, new Vec3(0, -0.5f, 0), Create.asResource("block/mechanical_roller/wheel"));
+    public static final TireLike ROCKCUTTING_WHEEL = new TireLike(0.8f, new Vec3(90, 0, 0), Vec3.ZERO, Offroad.path("block/rockcutting_wheel/wheel"), 0.0f);
+    public static final TireLike MECHANICAL_ROLLER = new TireLike(0.7f, Vec3.ZERO, new Vec3(0, -0.5f, 0), Create.asResource("block/mechanical_roller/wheel"), 0.0f);
 }


### PR DESCRIPTION
Useful for mods that add tires with anti-slip properties. I would've liked for this to support more advanced logic, such as different friction values for different surfaces, but because TireLikes have a codec and [number providers](https://minecraft.wiki/w/Number_provider) are exclusive to 26.3 this was the best I could do without massively overcomplicating things.