### PR TITLE
Fix bug where handle does not follow Newton's third law

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/config/server/physics/SimPhysics.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/config/server/physics/SimPhysics.java
@@ -18,6 +18,7 @@ public class SimPhysics extends ConfigBase {
     public final ConfigFloat dockingConnectorAngleTolerance = this.f(20.0f, 0, 365.0F, "docking_connector_angle", Comments.dockingConnectorAngleTolerance);
     public final ConfigFloat dockingConnectorDistanceTolerance = this.f(0.5F, 0, 4, "docking_connector_distance", Comments.dockingConnectorDistanceTolerance);
     public final ConfigFloat handleMaxForce = this.f(120.0f, 0, Float.MAX_VALUE,"handleMaxForce", Comments.handleMaxForce);
+    public final ConfigBool handleNewtonThirdLaw = this.b(true, "handleNewtonThirdLaw", Comments.handleNewtonThirdLaw);
 
     public final ConfigFloat physicsStaffLinearStiffness = this.f(2650.0f, 0, Float.MAX_VALUE, "physics_staff_linear_stiffness", SimPhysics.Comments.physicsStaffLinearStiffness);
     public final ConfigFloat physicsStaffLinearDamping = this.f(125.0f, 0, Float.MAX_VALUE, "physics_staff_linear_damping", SimPhysics.Comments.physicsStaffLinearDamping);
@@ -44,6 +45,7 @@ public class SimPhysics extends ConfigBase {
         private static final String dockingConnectorAngleTolerance = "The angle tolerance in degrees for docking connectors to link";
         private static final String dockingConnectorDistanceTolerance = "The distance tolerance in blocks for docking connectors to link";
         private static final String handleMaxForce = "The maximum force handles are allowed to apply to the contraption they are attached to";
+        private static final String handleNewtonThirdLaw = "Whether handles obey Newton's Third Law (equal and opposite reaction force on the contraption)";
 
         public static String physicsStaffLinearStiffness = "The linear stiffness of the joint motors used to hold sub-levels by the Creative Physics Staff";
         public static String physicsStaffLinearDamping = "The linear damping of the joint motors used to hold sub-levels by the Creative Physics Staff";

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/handle/HandleBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/handle/HandleBlockEntity.java
@@ -148,11 +148,14 @@ public class HandleBlockEntity extends SmartBlockEntity implements BlockEntitySu
                 return;
             }
 
+            final ServerSubLevel standingSubLevel = (ServerSubLevel) Sable.HELPER.getTrackingSubLevel(player);
+
+            boolean handleNewtonThirdLaw = SimConfigService.INSTANCE.server().physics.handleNewtonThirdLaw.get();
+
             if (!player.onGround() && !player.isInWater() && !player.getAbilities().flying &&!player.onClimbable()) {
                 return;
             } else {
-                final SubLevel standingSubLevel = Sable.HELPER.getTrackingSubLevel(player);
-                if (standingSubLevel == subLevel) {
+                if (standingSubLevel == subLevel && handleNewtonThirdLaw) {
                     return;
                 }
             }
@@ -172,10 +175,23 @@ public class HandleBlockEntity extends SmartBlockEntity implements BlockEntitySu
 
             final SubLevelPhysicsSystem physicsSystem = container.physicsSystem();
 
-            this.constraintHandle = physicsSystem.getPipeline().addConstraint(
-                    null, subLevel,
-                    new FreeConstraintConfiguration(constraintGoal, constraintPosition, new Quaterniond())
-            );
+            if (handleNewtonThirdLaw){
+                if (standingSubLevel != null) {
+                    standingSubLevel.logicalPose().transformPositionInverse(constraintGoal);
+                }
+
+                this.constraintHandle = physicsSystem.getPipeline().addConstraint(
+                        standingSubLevel, subLevel,
+                        new FreeConstraintConfiguration(constraintGoal, constraintPosition, new Quaterniond())
+                );
+            } else {
+                this.constraintHandle = physicsSystem.getPipeline().addConstraint(
+                        null, subLevel,
+                        new FreeConstraintConfiguration(constraintGoal, constraintPosition, new Quaterniond())
+                );
+            }
+
+
 
             final double maxForce = SimConfigService.INSTANCE.server().physics.handleMaxForce.getF();
 


### PR DESCRIPTION
When a player stands on a sub level A, holding down shift to grab the handle in sub level B will cause sub level B to move without moving sub level A under the player's feet. If sub level B is below sub level A or connected to sub level A by ropes or other means, the player can lift the two sub levels and themselves above them into the air.
<img width="678" height="488" alt="QQ20260725-180337" src="https://github.com/user-attachments/assets/6cf7efa1-8f3a-494a-8d62-df661c9dbd1e" />
But considering that many players have already used this feature to create many flying machines. So I added a server configuration item, and it's up to the server to decide whether the handle follows Newton's third law.