### PR TITLE
Add portable engine ComputerCraft peripheral

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/ComputerCraftPeripherals.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/ComputerCraftPeripherals.java
@@ -1,5 +1,6 @@
 package dev.simulated_team.simulated.compat.computercraft;
 
+import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.network.wired.WiredElement;
 import dev.simulated_team.simulated.compat.computercraft.peripherals.*;
 import dev.simulated_team.simulated.compat.computercraft.wired.DockingConnectorWiredElementImpl;
@@ -30,6 +31,8 @@ public class ComputerCraftPeripherals implements SimModCompatibilityService {
         service.addPeripheral(SimBlockEntityTypes.DOCKING_CONNECTOR, DockingConnectorPeripheral::new);
         service.addPeripheral(SimBlockEntityTypes.TORSION_SPRING, TorsionSpringPeripheral::new);
         service.addPeripheral(SimBlockEntityTypes.NAMEPLATE, NamePlatePeripheral::new);
+
+        ComputerCraftAPI.registerGenericSource(new PortableEnginePeripheral());
 
         service.addWired(SimBlockEntityTypes.DOCKING_CONNECTOR, (blockEntity, direction) -> {
             if (blockEntity.getBlockState().getValue(DockingConnectorBlock.FACING) == direction) {

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/PortableEnginePeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/PortableEnginePeripheral.java
@@ -1,0 +1,28 @@
+package dev.simulated_team.simulated.compat.computercraft.peripherals;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.peripheral.GenericPeripheral;
+import dev.simulated_team.simulated.Simulated;
+import dev.simulated_team.simulated.content.blocks.portable_engine.PortableEngineBlockEntity;
+
+public class PortableEnginePeripheral implements GenericPeripheral {
+    @Override
+    public String id() {
+        return Simulated.MOD_ID + ":portable_engine";
+    }
+
+    @LuaFunction
+    public final float getCurrentBurnTime(PortableEngineBlockEntity blockEntity) {
+        return (float) blockEntity.getCurrentBurnTime() / 20;
+    }
+
+    @LuaFunction(mainThread = true)
+    public final float getTotalBurnTime(PortableEngineBlockEntity blockEntity) {
+        return (float) blockEntity.getTotalBurnTime() / 20;
+    }
+
+    @LuaFunction
+    public final boolean isSuperHeated(PortableEngineBlockEntity blockEntity) {
+        return blockEntity.isSuperHeated();
+    }
+}


### PR DESCRIPTION
This adds three methods to any portable engine that's connected to a computer: `getCurrentBurnTime`, `getTotalBurnTime` and `isSuperHeated`.

I set `mainThread = true` on the `getTotalBurnTime` method out of an abundance of caution as it reads the engine's inventory which AFAIK can cause issues when multithreading, but I'm not sure if it's actually necessary or not as it's only reading it and not writing to it.