### PR TITLE
Add steering wheel ComputerCraft peripheral

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/ComputerCraftPeripherals.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/ComputerCraftPeripherals.java
@@ -20,6 +20,7 @@ public class ComputerCraftPeripherals implements SimModCompatibilityService {
         service.addPeripheral(SimBlockEntityTypes.NAVIGATION_TABLE, NavTablePeripheral::new);
         service.addPeripheral(SimBlockEntityTypes.LINKED_TYPEWRITER, LinkedTypewriterPeripheral::new);
         service.addPeripheral(SimBlockEntityTypes.OPTICAL_SENSOR, OpticalSensorPeripheral::new);
+        service.addPeripheral(SimBlockEntityTypes.STEERING_WHEEL, SteeringWheelPeripheral::new);
         service.addPeripheral(SimBlockEntityTypes.SWIVEL_BEARING, SwivelBearingPeripheral::new);
 
         service.addPeripheral(SimBlockEntityTypes.VELOCITY_SENSOR, VelocitySensorPeripheral::new);

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/SteeringWheelPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/SteeringWheelPeripheral.java
@@ -1,0 +1,46 @@
+package dev.simulated_team.simulated.compat.computercraft.peripherals;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dev.simulated_team.simulated.content.blocks.steering_wheel.SteeringWheelBlockEntity;
+
+public class SteeringWheelPeripheral extends SimPeripheral<SteeringWheelBlockEntity> {
+
+    public SteeringWheelPeripheral(SteeringWheelBlockEntity blockEntity) {
+        super(blockEntity);
+    }
+
+    @Override
+    public String getType() {
+        return "steering_wheel";
+    }
+
+    @LuaFunction
+    public final float getAngle() {
+        return blockEntity.getAngle();
+    }
+
+    @LuaFunction
+    public final float getTargetAngle() {
+        return blockEntity.targetAngleToUpdate;
+    }
+
+    @LuaFunction
+    public final void setTargetAngle(double angle) {
+        blockEntity.targetAngleToUpdate = (float)angle;
+    }
+
+    @LuaFunction
+    public final int getAngleLimit() {
+        return blockEntity.angleInput.getValue();
+    }
+
+    @LuaFunction
+    public final void setAngleLimit(int limit) {
+        blockEntity.angleInput.setValue(limit);
+    }
+
+    @LuaFunction
+    public final boolean isHeld() {
+        return blockEntity.held;
+    }
+}

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/SteeringWheelPeripheral.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/compat/computercraft/peripherals/SteeringWheelPeripheral.java
@@ -30,12 +30,12 @@ public class SteeringWheelPeripheral extends SimPeripheral<SteeringWheelBlockEnt
     }
 
     @LuaFunction
-    public final int getAngleLimit() {
+    public final int getLimit() {
         return blockEntity.angleInput.getValue();
     }
 
     @LuaFunction
-    public final void setAngleLimit(int limit) {
+    public final void setLimit(int limit) {
         blockEntity.angleInput.setValue(limit);
     }
 


### PR DESCRIPTION
This PR adds a ComputerCraft peripheral for steering wheels that allow computers to read and set the angle, as well as the limits:

- `getAngle` returns the current angle as output by the shaft at the bottom of the steering wheel
- `getTargetAngle` returns the angle that the user has selected, which may not correspond with the current angle when changing rapidly
- `setTargetAngle` sets the selected angle as if the user had selected it
- `getLimit` gets the user selected maximum angle
- `setLimit` sets the maximum allowed angle
- `isHeld` returns true if the user is currently interacting with the steering wheel

The `setTargetAngle` function could potentially be used as a way to get infinite rotation energy, but I feel like it's not a big deal due to the low SU capacity of the steering wheel (the smallest windmill will already generate twice as much SU)