### PR TITLE
Fix DiagramEntity orientation initialization

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/entities/diagram/DiagramEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/entities/diagram/DiagramEntity.java
@@ -68,7 +68,9 @@ public class DiagramEntity extends HangingEntity implements ISyncPersistentData,
     private static final Map<ResourceKey<Level>, Map<ServerSubLevel, DiagramRecordingTicket>> queuedDiagramRecordings = new WeakHashMap<>();
 
     protected int size;
-    protected Direction verticalOrientation;
+    // Entity-type construction happens before NBT is read. Keep a valid orientation
+    // so systems that inspect/save a newly-created entity cannot hit a null value.
+    protected Direction verticalOrientation = Direction.DOWN;
     protected DiagramConfig config;
 
     public static DiagramEntity create(final EntityType<? extends HangingEntity> entityType, final Level world) {


### PR DESCRIPTION
## Summary

- Initialize `DiagramEntity.verticalOrientation` to `Direction.DOWN` during construction.
- Prevent `addAdditionalSaveData()` from throwing when newly-created entities are inspected before NBT loading.

Closes #1370

## Validation

- `git diff --check`
- `./gradlew :simulated:common:compileJava`