### PR TITLE
Fix swivel bearing bugs when plate is in the main level

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/swivel_bearing/SwivelBearingBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/swivel_bearing/SwivelBearingBlockEntity.java
@@ -20,6 +20,7 @@ import dev.ryanhcode.sable.api.block.BlockEntitySubLevelActor;
 import dev.ryanhcode.sable.api.physics.PhysicsPipeline;
 import dev.ryanhcode.sable.api.physics.constraint.RotaryConstraintConfiguration;
 import dev.ryanhcode.sable.api.physics.constraint.RotaryConstraintHandle;
+import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
 import dev.ryanhcode.sable.api.schematic.SubLevelSchematicSerializationContext;
 import dev.ryanhcode.sable.api.sublevel.ServerSubLevelContainer;
 import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
@@ -794,6 +795,14 @@ public class SwivelBearingBlockEntity extends KineticBlockEntity implements Extr
     @Override
     public AssemblyException getLastAssemblyException() {
         return this.lastException;
+    }
+
+    //if the plate is in the main level, it won't update the servo coefficients for us
+    @Override
+    public void sable$physicsTick(ServerSubLevel subLevel, RigidBodyHandle handle, double timeStep) {
+        if (this.getSubLevelID() == null) {
+            this.updateServoCoefficients();
+        }
     }
 
     @Override

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/swivel_bearing/SwivelBearingBlockEntity.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/content/blocks/swivel_bearing/SwivelBearingBlockEntity.java
@@ -211,7 +211,7 @@ public class SwivelBearingBlockEntity extends KineticBlockEntity implements Extr
         }
 
         // check persistence to make sure we keep our sublevel after reload
-        if (this.getSubLevelID() != null) {
+        if (this.getSubLevelID() != null || this.isAssembled()) {
             this.checkPersistence(this.getSubLevelID());
         }
 


### PR DESCRIPTION
When the plate block of a swivel bearing is moved to the main level instead of a sublevel, the swivel bearing starts acting as if it's unlocked. If the world is then reloaded, the swivel bearing loses its constraint entirely and detaches from the plate (also known as the gleeble link exploit). This pull request fixes both of these bugs.

This is a video demonstrating the bugs: 

https://github.com/user-attachments/assets/7f39b7ca-21a0-4915-b894-871bbb0b9a12

