### PR TITLE
Fix creative tab crash caused by empty padding stacks

### DIFF
--- a/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/accessor/CreativeModeInventoryScreenSelectedTabAccessor.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/accessor/CreativeModeInventoryScreenSelectedTabAccessor.java
@@ -1,0 +1,15 @@
+package dev.simulated_team.simulated.mixin.accessor;
+
+import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
+import net.minecraft.world.item.CreativeModeTab;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(CreativeModeInventoryScreen.class)
+public interface CreativeModeInventoryScreenSelectedTabAccessor {
+
+	@Accessor("selectedTab")
+	static CreativeModeTab simulated$getSelectedTab() {
+		throw new AssertionError();
+	}
+}

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/creative_tab_sections/ItemPickerMenuMixin.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/mixin/creative_tab_sections/ItemPickerMenuMixin.java
@@ -1,7 +1,11 @@
 package dev.simulated_team.simulated.mixin.creative_tab_sections;
 
+import dev.simulated_team.simulated.mixin.accessor.CreativeModeInventoryScreenSelectedTabAccessor;
 import dev.simulated_team.simulated.registrate.simulated_tab.SimulatedCreativeTab;
+import dev.simulated_team.simulated.service.SimTabService;
 import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,8 +17,13 @@ public abstract class ItemPickerMenuMixin {
 
 	@Shadow protected abstract int getRowIndexForScroll(float f);
 
+	@Shadow public NonNullList<ItemStack> items;
+
 	@Inject(method = "scrollTo", at = @At("HEAD"))
 	private void simulated$scrollTo(final float f, final CallbackInfo ci) {
+		if(SimTabService.INSTANCE.getCreativeTab() == CreativeModeInventoryScreenSelectedTabAccessor.simulated$getSelectedTab()) {
+			SimulatedCreativeTab.padMenuItems(this.items);
+		}
 		SimulatedCreativeTab.CURRENT_ROW = this.getRowIndexForScroll(f);
 	}
 }

--- a/simulated/common/src/main/java/dev/simulated_team/simulated/registrate/simulated_tab/SimulatedCreativeTab.java
+++ b/simulated/common/src/main/java/dev/simulated_team/simulated/registrate/simulated_tab/SimulatedCreativeTab.java
@@ -11,6 +11,7 @@ import dev.simulated_team.simulated.mixin_interface.TickerExtension;
 import dev.simulated_team.simulated.registrate.SimulatedRegistrate;
 import foundry.veil.api.client.color.Color;
 import foundry.veil.api.client.color.Colorc;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -25,6 +26,7 @@ import net.minecraft.world.item.ItemStack;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -35,6 +37,12 @@ import java.util.function.Supplier;
 public class SimulatedCreativeTab {
 	public static int CURRENT_ROW = 0;
 	public static final Object2IntOpenHashMap<ResourceLocation> SECTION_Y_VALUES = new Object2IntOpenHashMap<>();
+	// Layout of the tab as rendered on screen: alternating runs of spacer rows and real items,
+	// encoded per run (negative = spacers, positive = real items). Spacers are never part of the
+	// tab's actual item lists, they are only inserted into the creative menu's display buffer.
+	private static final IntArrayList LAYOUT_PLAN = new IntArrayList();
+	private static int rawLayoutSize = 0;
+	private static int paddedLayoutSize = 0;
 
 	public static void renderBanners(final CreativeModeInventoryScreen screen, final GuiGraphics graphics, int mouseX, int mouseY) {
 		final PoseStack ps = graphics.pose();
@@ -136,9 +144,10 @@ public class SimulatedCreativeTab {
 			sectionMap.computeIfAbsent(section, (s) -> new LinkedList<>()).add(stack);
 		}
 
-		for (int i = 0; i < 9; i++) {
-			displayItems.accept(ItemStack.EMPTY);
-		}
+		LAYOUT_PLAN.clear();
+		rawLayoutSize = 0;
+		paddedLayoutSize = 0;
+		pushLayoutRun(true, 9);
 
 		int y = 0;
 		final List<SimulatedSection> sectionKeys = sectionMap.keySet().stream().sorted().toList();
@@ -152,6 +161,7 @@ public class SimulatedCreativeTab {
 				if(CreativeTabItemTransforms.VisibilityType.SEARCH_ONLY.has(item.getItem())) {
 					searchItems.accept(item);
 				} else if(!CreativeTabItemTransforms.VisibilityType.INVISIBLE.has(item.getItem())) {
+					pushLayoutRun(false, 1);
 					displayItems.accept(item);
 					searchItems.accept(item);
 					itemCount++;
@@ -171,10 +181,59 @@ public class SimulatedCreativeTab {
 			if(padding < 9) {
 				padding += 9;
 			}
-			for (int i = 0; i < padding; i++) {
-				displayItems.accept(ItemStack.EMPTY);
+			pushLayoutRun(true, padding);
+		}
+	}
+
+	private static void pushLayoutRun(final boolean spacer, final int count) {
+		if(count <= 0)
+			return;
+		final int encoded = spacer ? -count : count;
+		if(!LAYOUT_PLAN.isEmpty() && Integer.signum(LAYOUT_PLAN.getInt(LAYOUT_PLAN.size() - 1)) == Integer.signum(encoded)) {
+			LAYOUT_PLAN.set(LAYOUT_PLAN.size() - 1, LAYOUT_PLAN.getInt(LAYOUT_PLAN.size() - 1) + encoded);
+		} else {
+			LAYOUT_PLAN.add(encoded);
+		}
+		paddedLayoutSize += count;
+		if(!spacer) {
+			rawLayoutSize += count;
+		}
+	}
+
+	/**
+	 * Inserts the layout's empty spacing slots into the creative screen's item buffer.
+	 * The tab's real item lists never contain empty stacks; the spacing only exists visually,
+	 * so other mods reading creative tab contents can never run into {@link ItemStack#EMPTY}.
+	 */
+	public static void padMenuItems(final List<ItemStack> items) {
+		if(rawLayoutSize == 0 || rawLayoutSize == paddedLayoutSize)
+			return;
+		if(items.size() != rawLayoutSize && items.size() != paddedLayoutSize)
+			return;
+		if(items.size() == paddedLayoutSize)
+			return;
+
+		final List<ItemStack> padded = new ArrayList<>(paddedLayoutSize);
+		int source = 0;
+		for (int i = 0; i < LAYOUT_PLAN.size(); i++) {
+			final int run = LAYOUT_PLAN.getInt(i);
+			if(run < 0) {
+				for (int r = 0; r < -run; r++) {
+					padded.add(ItemStack.EMPTY);
+				}
+			} else {
+				for (int r = 0; r < run; r++) {
+					if(source >= items.size())
+						return;
+					padded.add(items.get(source++));
+				}
 			}
 		}
+		if(source != items.size())
+			return;
+
+		items.clear();
+		items.addAll(padded);
 	}
 
 	public static void setPlaying(ResourceLocation resourceLocation, boolean playing) {

--- a/simulated/common/src/main/resources/simulated.mixins.json
+++ b/simulated/common/src/main/resources/simulated.mixins.json
@@ -6,6 +6,7 @@
   "minVersion": "0.8",
   "client": [
     "accessor.CreativeModeInventoryScreenAccessor",
+    "accessor.CreativeModeInventoryScreenSelectedTabAccessor",
     "accessor.KeyMappingsAccessor",
     "accessor.LevelRendererAccessor",
     "conditional_display_target.DisplayLinkScreenMixin",


### PR DESCRIPTION
The simulated creative tab inserted raw ItemStack.EMPTY entries into its displayItems to reserve space for section banners. These air stacks ended up in the tab's shared item lists, so other mods anchoring creative tab entry insertions on list contents crashed with an
"IllegalArgumentException: Itemstack 0 minecraft:air does not exist in tab's list" when NeoForge dispatched BuildCreativeModeTabContentsEvent.

Spacing is now purely visual: processItems records a layout plan instead of emitting empty stacks, and ItemPickerMenuMixin applies the padding to the screen's item buffer at scroll time when the tab is selected. Tab contents no longer contain empty stacks while the in-game grid, banners and scrolling stay identical.