### PR TITLE
Add shapeless recipes to change an Envelope's color

### DIFF
--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/black_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/black_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:black_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:black_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/blue_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/blue_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:blue_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:blue_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/brown_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/brown_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:brown_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:brown_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/cyan_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/cyan_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:cyan_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:cyan_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/gray_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/gray_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:gray_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:gray_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/green_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/green_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:green_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:green_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/light_blue_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/light_blue_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:light_blue_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:light_blue_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/light_gray_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/light_gray_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:light_gray_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:light_gray_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/lime_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/lime_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:lime_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:lime_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/magenta_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/magenta_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:magenta_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:magenta_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/orange_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/orange_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:orange_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:orange_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/pink_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/pink_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:pink_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:pink_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/purple_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/purple_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:purple_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:purple_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/red_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/red_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:red_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:red_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/white_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/white_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:white_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:white_envelope"
+  }
+}

--- a/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/yellow_envelope.json
+++ b/aeronautics/common/src/generated/resources/data/aeronautics/recipe/dyeing/yellow_envelope.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "aeronautics:envelope",
+  "ingredients": [
+    {
+      "tag": "aeronautics:shaftless_envelope"
+    },
+    {
+      "item": "minecraft:yellow_dye"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "aeronautics:yellow_envelope"
+  }
+}


### PR DESCRIPTION
It's great that Hot Air Envelopes can come in all different colors.

However, it's weird that the only redyeing you can do to an already-crafted envelope, is bulk washing an envelope to turn it into a plain white envelope.

This PR attempts to fix that. Now, by combining one envelope with the appropriate dye, the envelope's color can be changed after the envelope is already crafted - similar to wool.